### PR TITLE
[feat] 동행 알림 기능 구현

### DIFF
--- a/src/main/java/com/arom/with_travel/domain/accompanies/dto/event/AccompanyAppliedEvent.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/dto/event/AccompanyAppliedEvent.java
@@ -1,0 +1,22 @@
+package com.arom.with_travel.domain.accompanies.dto.event;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AccompanyAppliedEvent {
+
+    private final Long accompanyId;
+    private final Long ownerId;
+    private final Long proposerId;
+    private final String proposerNickName;
+    private final LocalDateTime occurredAt = LocalDateTime.now();
+
+    public AccompanyAppliedEvent(Long accompanyId, Long ownerId, Long proposerId,  String proposerNickName) {
+        this.accompanyId = accompanyId;
+        this.ownerId = ownerId;
+        this.proposerId = proposerId;
+        this.proposerNickName = proposerNickName;
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/accompanies/model/Accompany.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/model/Accompany.java
@@ -128,7 +128,11 @@ public class Accompany extends BaseEntity {
         views++;
     }
 
-    private Long showViews(){
+    public Long getOwnerId(){
+        return member.getId();
+    }
+
+    public Long showViews(){
         return views;
     }
 

--- a/src/main/java/com/arom/with_travel/domain/accompanies/service/AccompanyService.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/service/AccompanyService.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.accompanies.service;
 
+import com.arom.with_travel.domain.accompanies.dto.event.AccompanyAppliedEvent;
 import com.arom.with_travel.domain.accompanies.dto.response.AccompanyBriefResponse;
 import com.arom.with_travel.domain.accompanies.model.Accompany;
 import com.arom.with_travel.domain.accompanies.model.AccompanyApply;
@@ -17,13 +18,10 @@ import com.arom.with_travel.global.exception.BaseException;
 import com.arom.with_travel.global.exception.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -34,10 +32,11 @@ public class AccompanyService {
     private final MemberRepository memberRepository;
     private final LikesRepository likesRepository;
     private final AccompanyApplyRepository applyRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public String save(AccompanyPostRequest request, Long memberId) {
-        Member member = findMember(memberId);
+        Member member = loadMemberOrThrow(memberId);
         Accompany accompany = Accompany.from(request);
         accompany.post(member);
         accompanyRepository.save(accompany);
@@ -46,8 +45,8 @@ public class AccompanyService {
 
     @Transactional
     public boolean pressLike(Long accompanyId, Long memberId){
-        Member member = findMember(memberId);
-        Accompany accompany = findAccompany(accompanyId);
+        Member member = loadMemberOrThrow(memberId);
+        Accompany accompany = loadAccompanyOrThrow(accompanyId);
         if(accompany.isAlreadyLikedBy(memberId)) {
             return false;
         }
@@ -59,18 +58,24 @@ public class AccompanyService {
 
     @Transactional
     public AccompanyDetailsResponse showDetails(Long accompanyId){
-        Accompany accompany = findAccompany(accompanyId);
+        Accompany accompany = loadAccompanyOrThrow(accompanyId);
         accompany.addView();
         return AccompanyDetailsResponse.from(accompany);
     }
 
     @Transactional
     public String applyAccompany(Long accompanyId, Long memberId){
-        Accompany accompany = findAccompany(accompanyId);
-        Member member = findMember(memberId);
-        isAlreadyApplied(member, accompany);
-        applyRepository.save(AccompanyApply.apply(accompany, member));
-        // TODO : 동행 작성자에게 참가 수락여부 알림이 가야 함
+        Accompany accompany = loadAccompanyOrThrow(accompanyId);
+        Member proposer = loadMemberOrThrow(memberId);
+        proposer.validateNotAlreadyAppliedTo(accompany);
+        applyRepository.save(AccompanyApply.apply(accompany, proposer));
+        AccompanyAppliedEvent event = new AccompanyAppliedEvent(
+                accompany.getId(),
+                accompany.getOwnerId(),
+                proposer.getId(),
+                proposer.getNickname()
+        );
+        eventPublisher.publishEvent(event);
         return "참가 신청이 완료됐습니다.";
     }
 
@@ -82,23 +87,13 @@ public class AccompanyService {
     }
 
     // 임시 조회 코드
-    private Member findMember(Long memberId){
+    private Member loadMemberOrThrow(Long memberId){
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
     }
 
-    private Accompany findAccompany(Long accompanyId){
+    private Accompany loadAccompanyOrThrow(Long accompanyId){
         return accompanyRepository.findById(accompanyId)
                 .orElseThrow(() -> BaseException.from(ErrorCode.ACCOMPANY_NOT_FOUND));
-    }
-
-    private void isAlreadyApplied(Member member, Accompany accompany) {
-        member.getAccompanyApplies()
-                .stream()
-                .map(accompanyApply ->{
-                    if(accompanyApply.getAccompanies().equals(accompany))
-                        throw BaseException.from(ErrorCode.TMP_ERROR);
-                    return null;
-                });
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -14,6 +14,8 @@ import com.arom.with_travel.domain.shorts.Shorts;
 import com.arom.with_travel.domain.shorts_reply.ShortsReply;
 import com.arom.with_travel.domain.survey.Survey;
 import com.arom.with_travel.global.entity.BaseEntity;
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -36,7 +38,7 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-     private String oauthId;
+    private String oauthId;
     private String email;
     private LocalDate birth = LocalDate.now();
     @Enumerated(EnumType.STRING) private Gender gender;
@@ -108,9 +110,6 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<Survey> surveys = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
-    private List<Notification> notifications = new ArrayList<>();
-
     @OneToOne(mappedBy = "member")
     private Image image;
 
@@ -129,5 +128,13 @@ public class Member extends BaseEntity {
         this.introduction = introduction;
         this.travelType = travelType;
         this.role = role;
+    }
+
+    public void validateNotAlreadyAppliedTo(Accompany accompany) {
+        boolean alreadyApplied = accompanyApplies.stream()
+                .anyMatch(apply -> apply.getAccompanies().equals(accompany));
+        if (alreadyApplied) {
+            throw BaseException.from(ErrorCode.TMP_ERROR);
+        }
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/notification/Notification.java
+++ b/src/main/java/com/arom/with_travel/domain/notification/Notification.java
@@ -4,21 +4,44 @@ import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.aspectj.weaver.ast.Not;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification extends BaseEntity {
+public class Notification{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private Long senderId;
+    private Long receiverId;
+    private String message;
+    private String targetUrl;
+    private Boolean isRead = false;
+    private LocalDateTime occuredAt;
 
-    private String content;
+    @Builder
+    private Notification(Long senderId, Long receiverId, String message, String targetUrl, LocalDateTime occuredAt) {
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+        this.message = message;
+        this.targetUrl = targetUrl;
+        this.occuredAt = occuredAt;
+    }
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    public static Notification from(Long senderId, Long receiverId, String message, String targetUrl, LocalDateTime occuredAt) {
+        return Notification.builder()
+                .message(message)
+                .receiverId(receiverId)
+                .senderId(senderId)
+                .targetUrl(targetUrl)
+                .occuredAt(occuredAt)
+                .build();
+    }
 }

--- a/src/main/java/com/arom/with_travel/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/arom/with_travel/domain/notification/controller/NotificationController.java
@@ -1,10 +1,14 @@
 package com.arom.with_travel.domain.notification.controller;
 
+import com.arom.with_travel.domain.notification.dto.NotificationResponse;
 import com.arom.with_travel.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,5 +18,18 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    // 사용자별 알림 구독 엔드포인트
+    // 예: GET /notifications/subscribe/1 => 사용자 ID가 1인 사용자가 구독
+    @GetMapping("/subscribe/{userId}")
+    public SseEmitter subscribe(@PathVariable Long userId) {
+        return notificationService.subscribe(userId);
+    }
 
+    @GetMapping("/slice")
+    public Slice<NotificationResponse> getNotificationsSlice(
+            @RequestParam Long receiverId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return notificationService.getNotifications(receiverId, page, size);
+    }
 }

--- a/src/main/java/com/arom/with_travel/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,20 @@
+package com.arom.with_travel.domain.notification.dto;
+
+import com.arom.with_travel.domain.notification.Notification;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NotificationResponse {
+    private String message;
+    private Boolean isRead;
+    private String targetUrl;
+
+    public static NotificationResponse from(Notification notification) {
+        return NotificationResponse.builder()
+                .message(notification.getMessage())
+                .isRead(notification.getIsRead())
+                .build();
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/notification/eventListner/NotificationEventListener.java
+++ b/src/main/java/com/arom/with_travel/domain/notification/eventListner/NotificationEventListener.java
@@ -1,0 +1,19 @@
+package com.arom.with_travel.domain.notification.eventListner;
+
+import com.arom.with_travel.domain.accompanies.dto.event.AccompanyAppliedEvent;
+import com.arom.with_travel.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    public void handleAccompanyAppliedEvent(AccompanyAppliedEvent event) {
+        notificationService.sendNotification(event);
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/notification/properties/NotificationProperties.java
+++ b/src/main/java/com/arom/with_travel/domain/notification/properties/NotificationProperties.java
@@ -1,0 +1,7 @@
+package com.arom.with_travel.domain.notification.properties;
+
+public class NotificationProperties {
+
+    public static final String ACCOMPANY_APPLY_MESSAGE = "님이 동행신청을 했습니다.";
+    public static final String ACCOMPANY_NOTICE_TARGET_URL_PREFIX = "/api/v1/accompanies/";
+}

--- a/src/main/java/com/arom/with_travel/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/notification/repository/NotificationRepository.java
@@ -1,7 +1,16 @@
 package com.arom.with_travel.domain.notification.repository;
 
 import com.arom.with_travel.domain.notification.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM Notification n WHERE n.receiverId = :receiverId")
+    Slice<Notification> findByReceiverIdOrderByOccurredAtDesc(@Param("receiverId") Long receiverId, Pageable pageable);
 }

--- a/src/main/java/com/arom/with_travel/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/arom/with_travel/domain/notification/service/NotificationService.java
@@ -1,12 +1,81 @@
 package com.arom.with_travel.domain.notification.service;
 
+import com.arom.with_travel.domain.accompanies.dto.event.AccompanyAppliedEvent;
+import com.arom.with_travel.domain.notification.Notification;
+import com.arom.with_travel.domain.notification.dto.NotificationResponse;
+import com.arom.with_travel.domain.notification.properties.NotificationProperties;
+import com.arom.with_travel.domain.notification.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
+    // 사용자 ID별로 여러 SseEmitter를 저장 (멀티 디바이스 대응)
+    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+    private final NotificationRepository notificationRepository;
 
+    // 사용자별 SSE 구독 등록
+    public SseEmitter subscribe(Long userId) {
+        // 타임아웃은 30분 설정 (필요에 따라 조정)
+        SseEmitter emitter = new SseEmitter(30 * 60 * 1000L);
+        emitters.computeIfAbsent(userId, key -> new CopyOnWriteArrayList<>()).add(emitter);
 
+        // 연결 종료 또는 오류 발생 시 emitter 제거
+        emitter.onCompletion(() -> removeEmitter(userId, emitter));
+        emitter.onTimeout(() -> removeEmitter(userId, emitter));
+        emitter.onError((e) -> removeEmitter(userId, emitter));
 
+        return emitter;
+    }
+
+    // 알림 전송 메서드
+    public void sendNotification(AccompanyAppliedEvent event) {
+        List<SseEmitter> userEmitters = emitters.get(event.getOwnerId());
+        String notificationMessage = event.getProposerNickName() + NotificationProperties.ACCOMPANY_APPLY_MESSAGE;
+        String targetUrl = NotificationProperties.ACCOMPANY_NOTICE_TARGET_URL_PREFIX + event.getAccompanyId();
+        if (userEmitters != null) {
+            // 등록된 모든 emitter에 알림 전송
+            for (SseEmitter emitter : userEmitters) {
+                try {
+                    emitter.send(SseEmitter.event().name("notification").data(notificationMessage));
+                } catch (IOException e) {
+                    removeEmitter(event.getOwnerId(), emitter);
+                }
+            }
+        }
+        Notification notification = Notification.from(
+                event.getProposerId(),
+                event.getOwnerId(),
+                notificationMessage,
+                targetUrl,
+                event.getOccurredAt()
+        );
+        notificationRepository.save(notification);
+    }
+
+    public Slice<NotificationResponse> getNotifications(Long receiverId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("occurredAt").descending());
+        Slice<Notification> notifications = notificationRepository.findByReceiverIdOrderByOccurredAtDesc(receiverId, pageable);
+        return notifications.map(NotificationResponse::from);
+    }
+
+    // emitter 제거
+    private void removeEmitter(Long userId, SseEmitter emitter) {
+        List<SseEmitter> userEmitters = emitters.get(userId);
+        if (userEmitters != null) {
+            userEmitters.remove(emitter);
+        }
+    }
 }


### PR DESCRIPTION
# 이슈
- #28 

# 구현 기능

동행 신청시 동행 게시자에게 신청 알림 기능을 구현

- **실시간 알림 구현 (SSE 적용)**
  - 사용자가 알림 구독 시 SSE(SseEmitter)를 통한 실시간 알림 전송 기능을 추가하였습니다.
  - NotificationService에서 등록된 SSE 연결에 대해 알림을 전송하고, 전송 실패 시 해당 연결을 정리하도록 구현하였습니다.

- **도메인 이벤트 기반 알림 처리**
  - 동행 신청 완료 시 AccompanyAppliedEvent 도메인 이벤트를 발행하여, NotificationEventListener에서 해당 이벤트를 처리하도록 변경하였습니다.
  - 이벤트 리스너 내에서 게시글 작성자(알림 수신 대상)에게 알림 전송 및 알림 이력을 저장하는 로직을 추가하였습니다.

- **알림 이력 및 무한 스크롤 지원 API**
  - Notification 엔티티에 receiver의 userId를 기반으로 알림을 저장하도록 변경하였으며, 연관관계 매핑 없이 단순 조회를 위해 userId 필드를 사용합니다.
  - NotificationRepository에서 Slice를 활용하여 count 쿼리 없이 무한 스크롤 형태의 알림 조회 기능을 구현하였습니다.
  - NotificationResponse DTO를 도입하여 클라이언트에 메시지, 읽음 여부, 이동 URL 등의 정보를 전달합니다.


# 작업 시간
