### PR TITLE
[refactor] 예외처리 구조 변경

### DIFF
--- a/src/main/java/com/arom/with_travel/domain/accompanies/controller/AccompanySearchController.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/controller/AccompanySearchController.java
@@ -38,7 +38,7 @@ public class AccompanySearchController {
             @RequestParam(required = false) Long lastId,
             @RequestParam(defaultValue = "10") int size
     ) {
-        return accompanySearchService.getFilteredAccompanies(continent, country, city, startDate, lastId, size);
+        return accompanySearchService.getFilteredAccompanies(keyword, continent, country, city, startDate, lastId, size);
     }
 
     // 아직은 대륙별 검색 기능만 제공

--- a/src/main/java/com/arom/with_travel/domain/accompanies/error/AccompanyErrorCode.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/error/AccompanyErrorCode.java
@@ -1,0 +1,22 @@
+package com.arom.with_travel.domain.accompanies.error;
+
+import com.arom.with_travel.global.exception.error.BaseCode;
+import com.arom.with_travel.global.exception.error.ErrorDisplayType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AccompanyErrorCode implements BaseCode {
+
+    ACCOMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST,"ACC-0000", "해당 동행이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    ACCOMPANY_ALREADY_APPLIED(HttpStatus.BAD_REQUEST,"ACC-0001", "이미 신청한 동행입니다.", ErrorDisplayType.POPUP),
+    ACCOMPANY_POST_ERROR(HttpStatus.BAD_REQUEST,"ACC-0002", "동행 입력이 올바르지 않습니다.", ErrorDisplayType.POPUP)
+    // ACCOMPANY_ALREADY_CONFIRMED("ACC-0002", "참가 확정된 동행입니다.", ErrorDisplayType.POPUP)
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private final ErrorDisplayType displayType;
+}

--- a/src/main/java/com/arom/with_travel/domain/accompanies/model/AccompanyType.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/model/AccompanyType.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.accompanies.model;
 
+import com.arom.with_travel.domain.accompanies.error.AccompanyErrorCode;
 import com.arom.with_travel.global.exception.BaseException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -8,7 +9,6 @@ import lombok.Getter;
 
 import java.util.Arrays;
 
-import static com.arom.with_travel.global.exception.error.ErrorCode.ACCOMPANY_POST_ERROR;
 
 @Getter
 @AllArgsConstructor
@@ -31,6 +31,6 @@ public enum AccompanyType {
         return Arrays.stream(values())
                 .filter(type -> type.getType().equals(val))
                 .findAny()
-                .orElseThrow(() -> BaseException.from(ACCOMPANY_POST_ERROR));
+                .orElseThrow(() -> BaseException.from(AccompanyErrorCode.ACCOMPANY_POST_ERROR));
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/accompanies/model/City.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/model/City.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.accompanies.model;
 
+import com.arom.with_travel.domain.accompanies.error.AccompanyErrorCode;
 import com.arom.with_travel.global.exception.BaseException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -7,8 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Arrays;
-
-import static com.arom.with_travel.global.exception.error.ErrorCode.ACCOMPANY_POST_ERROR;
 
 @Getter
 @AllArgsConstructor
@@ -25,6 +24,6 @@ public enum City {
         return Arrays.stream(values())
                 .filter(type -> type.getName().equals(val))
                 .findAny()
-                .orElseThrow(() -> BaseException.from(ACCOMPANY_POST_ERROR));
+                .orElseThrow(() -> BaseException.from(AccompanyErrorCode.ACCOMPANY_POST_ERROR));
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/accompanies/model/Continent.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/model/Continent.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.accompanies.model;
 
+import com.arom.with_travel.domain.accompanies.error.AccompanyErrorCode;
 import com.arom.with_travel.global.exception.BaseException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -7,8 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Arrays;
-
-import static com.arom.with_travel.global.exception.error.ErrorCode.ACCOMPANY_POST_ERROR;
 
 @Getter
 @AllArgsConstructor
@@ -22,6 +21,6 @@ public enum Continent {
         return Arrays.stream(values())
                 .filter(type -> type.getName().equals(val))
                 .findAny()
-                .orElseThrow(() -> BaseException.from(ACCOMPANY_POST_ERROR));
+                .orElseThrow(() -> BaseException.from(AccompanyErrorCode.ACCOMPANY_POST_ERROR));
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/accompanies/model/Country.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/model/Country.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.accompanies.model;
 
+import com.arom.with_travel.domain.accompanies.error.AccompanyErrorCode;
 import com.arom.with_travel.global.exception.BaseException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -8,7 +9,6 @@ import lombok.Getter;
 
 import java.util.Arrays;
 
-import static com.arom.with_travel.global.exception.error.ErrorCode.ACCOMPANY_POST_ERROR;
 
 @Getter
 @AllArgsConstructor
@@ -22,6 +22,6 @@ public enum Country {
         return Arrays.stream(values())
                 .filter(type -> type.getName().equals(val))
                 .findAny()
-                .orElseThrow(() -> BaseException.from(ACCOMPANY_POST_ERROR));
+                .orElseThrow(() -> BaseException.from(AccompanyErrorCode.ACCOMPANY_POST_ERROR));
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/accompanies/repository/accompany/AccompanyRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/repository/accompany/AccompanyRepository.java
@@ -38,9 +38,15 @@ public interface AccompanyRepository extends
         (a.createdAt < :lastCreatedAt) OR 
         (a.createdAt = :lastCreatedAt AND a.id < :lastId)
     )
+    AND (
+            :keyword IS NULL OR
+            LOWER(a.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+            LOWER(a.description) LIKE LOWER(CONCAT('%', :keyword, '%'))
+        )
     ORDER BY a.createdAt DESC, a.id DESC
 """)
     Slice<Accompany> findByFiltersWithNoOffset(
+            @Param("keyword") String keyword,
             @Param("continent") Continent continent,
             @Param("country") Country country,
             @Param("city") City city,

--- a/src/main/java/com/arom/with_travel/domain/accompanies/service/AccompanySearchService.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/service/AccompanySearchService.java
@@ -31,7 +31,9 @@ public class AccompanySearchService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public Slice<AccompanyBriefResponse> getFilteredAccompanies(
+            String keyword,
             Continent continent,
             Country country,
             City city,
@@ -41,6 +43,7 @@ public class AccompanySearchService {
     ) {
         Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         return accompanyRepository.findByFiltersWithNoOffset(
+                keyword,
                 continent,
                 country,
                 city,

--- a/src/main/java/com/arom/with_travel/domain/accompanies/service/AccompanyService.java
+++ b/src/main/java/com/arom/with_travel/domain/accompanies/service/AccompanyService.java
@@ -2,6 +2,7 @@ package com.arom.with_travel.domain.accompanies.service;
 
 import com.arom.with_travel.domain.accompanies.dto.event.AccompanyAppliedEvent;
 import com.arom.with_travel.domain.accompanies.dto.response.AccompanyBriefResponse;
+import com.arom.with_travel.domain.accompanies.error.AccompanyErrorCode;
 import com.arom.with_travel.domain.accompanies.model.Accompany;
 import com.arom.with_travel.domain.accompanies.model.AccompanyApply;
 import com.arom.with_travel.domain.accompanies.dto.request.AccompanyPostRequest;
@@ -13,6 +14,7 @@ import com.arom.with_travel.domain.accompanies.repository.accompanyApply.Accompa
 import com.arom.with_travel.domain.likes.Likes;
 import com.arom.with_travel.domain.likes.repository.LikesRepository;
 import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.error.MemberErrorCode;
 import com.arom.with_travel.domain.member.repository.MemberRepository;
 import com.arom.with_travel.global.exception.BaseException;
 import com.arom.with_travel.global.exception.error.ErrorCode;
@@ -89,11 +91,11 @@ public class AccompanyService {
     // 임시 조회 코드
     private Member loadMemberOrThrow(Long memberId){
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
     private Accompany loadAccompanyOrThrow(Long accompanyId){
         return accompanyRepository.findById(accompanyId)
-                .orElseThrow(() -> BaseException.from(ErrorCode.ACCOMPANY_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(AccompanyErrorCode.ACCOMPANY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -9,13 +9,13 @@ import com.arom.with_travel.domain.community.Community;
 import com.arom.with_travel.domain.community_reply.CommunityReply;
 import com.arom.with_travel.domain.image.Image;
 import com.arom.with_travel.domain.likes.Likes;
+import com.arom.with_travel.domain.member.error.MemberErrorCode;
 import com.arom.with_travel.domain.notification.Notification;
 import com.arom.with_travel.domain.shorts.Shorts;
 import com.arom.with_travel.domain.shorts_reply.ShortsReply;
 import com.arom.with_travel.domain.survey.Survey;
 import com.arom.with_travel.global.entity.BaseEntity;
 import com.arom.with_travel.global.exception.BaseException;
-import com.arom.with_travel.global.exception.error.ErrorCode;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -135,7 +135,7 @@ public class Member extends BaseEntity {
         boolean alreadyApplied = accompanyApplies.stream()
                 .anyMatch(apply -> apply.getAccompanies().equals(accompany));
         if (alreadyApplied) {
-            throw BaseException.from(ErrorCode.TMP_ERROR);
+            throw BaseException.from(MemberErrorCode.MEMBER_ALREADY_REGISTERED);
         }
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/com/arom/with_travel/domain/member/error/MemberErrorCode.java
@@ -1,0 +1,21 @@
+package com.arom.with_travel.domain.member.error;
+
+import com.arom.with_travel.global.exception.error.BaseCode;
+import com.arom.with_travel.global.exception.error.ErrorDisplayType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum MemberErrorCode implements BaseCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"MEM-0000", "해당 회원이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    MEMBER_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST,"MEM-0001", "이미 회원가입되어 있습니다.", ErrorDisplayType.POPUP)
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private final ErrorDisplayType displayType;
+}

--- a/src/main/java/com/arom/with_travel/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/arom/with_travel/domain/member/service/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package com.arom.with_travel.domain.member.service;
 
 import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.error.MemberErrorCode;
 import com.arom.with_travel.domain.member.repository.MemberRepository;
 import com.arom.with_travel.global.exception.BaseException;
 import com.arom.with_travel.global.exception.error.ErrorCode;
@@ -21,13 +22,13 @@ public class MemberServiceImpl implements MemberService {
     // userId로 유저 조회, 실패 시 에러 발생
     public Member getUserByUserIdOrElseThrow(Long userId) {
         return memberRepository.findById(userId)
-                .orElseThrow(() ->  BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() ->  BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
     @Override
     // loginEmail로 유저 조회, 실패 시 에러 발생
     public Member getUserByLoginEmailOrElseThrow(String loginEmail) {
         return memberRepository.findByEmail(loginEmail)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/service/MemberSignupService.java
+++ b/src/main/java/com/arom/with_travel/domain/member/service/MemberSignupService.java
@@ -2,6 +2,7 @@ package com.arom.with_travel.domain.member.service;
 
 import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.member.dto.MemberSignupRequestDto;
+import com.arom.with_travel.domain.member.error.MemberErrorCode;
 import com.arom.with_travel.domain.member.repository.MemberRepository;
 import com.arom.with_travel.global.exception.BaseException;
 import com.arom.with_travel.global.exception.error.ErrorCode;
@@ -19,10 +20,10 @@ public class MemberSignupService {
     public Member registerMember(String email, MemberSignupRequestDto requestDto) {
 
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if (member.getRole() == Member.Role.USER) {
-            throw BaseException.from(ErrorCode.MEMBER_ALREADY_REGISTERED);
+            throw BaseException.from(MemberErrorCode.MEMBER_ALREADY_REGISTERED);
         }
 
         member.setNickname(requestDto.getNickname());
@@ -35,11 +36,11 @@ public class MemberSignupService {
 
     public Member getMemberByIdOrElseThrow(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
     public Member getMemberByEmailOrElseThrow(String email) {
         return memberRepository.findByEmail(email)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/survey/error/SurveyErrorCode.java
+++ b/src/main/java/com/arom/with_travel/domain/survey/error/SurveyErrorCode.java
@@ -1,0 +1,21 @@
+package com.arom.with_travel.domain.survey.error;
+
+import com.arom.with_travel.global.exception.error.BaseCode;
+import com.arom.with_travel.global.exception.error.ErrorDisplayType;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SurveyErrorCode implements BaseCode {
+
+    SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND,"SVY-0000", "해당 설문이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private final ErrorDisplayType displayType;
+}

--- a/src/main/java/com/arom/with_travel/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/arom/with_travel/domain/survey/service/SurveyService.java
@@ -1,9 +1,11 @@
 package com.arom.with_travel.domain.survey.service;
 
 import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.error.MemberErrorCode;
 import com.arom.with_travel.domain.member.repository.MemberRepository;
 import com.arom.with_travel.domain.survey.Survey;
 import com.arom.with_travel.domain.survey.dto.request.SurveyRequestDto;
+import com.arom.with_travel.domain.survey.error.SurveyErrorCode;
 import com.arom.with_travel.domain.survey.repository.SurveyRepository;
 import com.arom.with_travel.global.exception.BaseException;
 import com.arom.with_travel.global.exception.error.ErrorCode;
@@ -21,7 +23,7 @@ public class SurveyService {
 
     public Survey createSurvey(String email, SurveyRequestDto dto) {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));;
+                .orElseThrow(() -> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));;
 
         Survey survey = Survey.builder()
                 .member(member)
@@ -35,12 +37,12 @@ public class SurveyService {
 
     public Survey getSurvey(Long surveyId) {
         return surveyRepository.findById(surveyId)
-                .orElseThrow(() -> BaseException.from(ErrorCode.SURVEY_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(SurveyErrorCode.SURVEY_NOT_FOUND));
     }
 
     public List<Survey> getSurveysByEmail(String email) {
         Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(MemberErrorCode.MEMBER_NOT_FOUND));
 
         return surveyRepository.findByMember(member);
     }

--- a/src/main/java/com/arom/with_travel/global/exception/BaseException.java
+++ b/src/main/java/com/arom/with_travel/global/exception/BaseException.java
@@ -1,20 +1,21 @@
 package com.arom.with_travel.global.exception;
 
+import com.arom.with_travel.global.exception.error.BaseCode;
 import com.arom.with_travel.global.exception.error.ErrorCode;
 import lombok.Getter;
 
 @Getter
 public class BaseException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final BaseCode code;
     private String customErrorMessage;
 
-    private BaseException(ErrorCode code) {
-        this.errorCode = code;
+    private BaseException(BaseCode code) {
+        this.code = code;
     }
 
-    private BaseException(ErrorCode code, final String message) {
-        this.errorCode = code;
+    private BaseException(BaseCode code, final String message) {
+        this.code = code;
         this.customErrorMessage = message;
     }
 
@@ -22,11 +23,11 @@ public class BaseException extends RuntimeException {
         return customErrorMessage != null;
     }
 
-    public static BaseException from(ErrorCode errorCode) {
-        return new BaseException(errorCode);
+    public static BaseException from(BaseCode code) {
+        return new BaseException(code);
     }
 
-    public static BaseException from(ErrorCode errorCode, final String customErrorMessage){
-        return new BaseException(errorCode, customErrorMessage);
+    public static BaseException from(BaseCode code, final String customErrorMessage){
+        return new BaseException(code, customErrorMessage);
     }
 }

--- a/src/main/java/com/arom/with_travel/global/exception/error/BaseCode.java
+++ b/src/main/java/com/arom/with_travel/global/exception/error/BaseCode.java
@@ -1,0 +1,10 @@
+package com.arom.with_travel.global.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+    ErrorDisplayType getDisplayType();
+}

--- a/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
@@ -6,31 +6,31 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorCode {
+public enum ErrorCode implements BaseCode{
 
-    TMP_ERROR("S3-0000", "파일 형식이 올바르지 않습니다.", ErrorDisplayType.MODAL),
+    TMP_ERROR(HttpStatus.BAD_REQUEST, "S3-0000", "파일 형식이 올바르지 않습니다.", ErrorDisplayType.MODAL),
 
     //client error : 4xx
 
     //member
-    MEMBER_NOT_FOUND("MEM-0000", "해당 회원이 존재하지 않습니다.", ErrorDisplayType.POPUP),
-    MEMBER_ALREADY_REGISTERED("MEM-0001", "이미 회원가입되어 있습니다.", ErrorDisplayType.POPUP),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"MEM-0000", "해당 회원이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    MEMBER_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST,"MEM-0001", "이미 회원가입되어 있습니다.", ErrorDisplayType.POPUP),
 
     //token
-    TOKEN_NOT_FOUND("TKN-0000", "refresh token이 존재하지 않습니다.", ErrorDisplayType.POPUP),
-    INVALID_TOKEN("TKN-0001", "유효하지 않은 token입니다.", ErrorDisplayType.POPUP),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"TKN-0000", "refresh token이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"TKN-0001", "유효하지 않은 token입니다.", ErrorDisplayType.POPUP),
 
     //accompany
-    ACCOMPANY_NOT_FOUND("ACC-0000", "해당 동행이 존재하지 않습니다.", ErrorDisplayType.POPUP),
-    ACCOMPANY_ALREADY_APPLIED("ACC-0001", "이미 신청한 동행입니다.", ErrorDisplayType.POPUP),
-    ACCOMPANY_POST_ERROR("ACC-0002", "동행 입력이 올바르지 않습니다.", ErrorDisplayType.POPUP),
+    ACCOMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST,"ACC-0000", "해당 동행이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    ACCOMPANY_ALREADY_APPLIED(HttpStatus.BAD_REQUEST,"ACC-0001", "이미 신청한 동행입니다.", ErrorDisplayType.POPUP),
+    ACCOMPANY_POST_ERROR(HttpStatus.BAD_REQUEST,"ACC-0002", "동행 입력이 올바르지 않습니다.", ErrorDisplayType.POPUP),
     // ACCOMPANY_ALREADY_CONFIRMED("ACC-0002", "참가 확정된 동행입니다.", ErrorDisplayType.POPUP)
 
     //survey
-    SURVEY_NOT_FOUND("SVY-0000", "해당 설문이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND,"SVY-0000", "해당 설문이 존재하지 않습니다.", ErrorDisplayType.POPUP),
     ;
 
-
+    private final HttpStatus status;
     private final String code;
     private final String message;
     private final ErrorDisplayType displayType;

--- a/src/main/java/com/arom/with_travel/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/arom/with_travel/global/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.arom.with_travel.global.exception.error.ErrorCode;
 import com.arom.with_travel.global.exception.error.ErrorDisplayType;
 import com.arom.with_travel.global.exception.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,22 +15,20 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(annotations = {RestController.class})
 public class GlobalExceptionHandler {
 
-    /**
-     * 클라이언트 에러
-     * 직접 생성한 예외에 대한 처리
-     */
+
     @ExceptionHandler(BaseException.class)
-    public ErrorResponse onThrowException(BaseException baseException) {
-        return ErrorResponse.generateErrorResponse(baseException);
+    public ResponseEntity<ErrorResponse> onThrowException(BaseException baseException) {
+        ErrorResponse response = ErrorResponse.generateErrorResponse(baseException);
+        return ResponseEntity.status(baseException.getCode().getStatus()).body(response);
     }
 
-    // TODO : 바인딩 에러 관련 ErrorCode 작성
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ErrorResponse onThrowException(MethodArgumentNotValidException exception){
-        return ErrorResponse.builder()
+    public ResponseEntity<ErrorResponse> onThrowException(MethodArgumentNotValidException exception){
+        ErrorResponse response = ErrorResponse.builder()
                 .code(ErrorCode.TMP_ERROR.getCode())
                 .message(exception.getBindingResult().getFieldError().getDefaultMessage())
                 .displayType(ErrorDisplayType.POPUP)
                 .build();
+        return ResponseEntity.status(exception.getStatusCode()).body(response);
     }
 }

--- a/src/main/java/com/arom/with_travel/global/exception/response/ErrorResponse.java
+++ b/src/main/java/com/arom/with_travel/global/exception/response/ErrorResponse.java
@@ -23,13 +23,13 @@ public class ErrorResponse {
     public static ErrorResponse generateErrorResponse(BaseException baseException){
         if(baseException.hasCustomMessage()) {
             return new ErrorResponse(
-                    baseException.getErrorCode().getCode(),
+                    baseException.getCode().getCode(),
                     baseException.getCustomErrorMessage(),
-                    baseException.getErrorCode().getDisplayType());
+                    baseException.getCode().getDisplayType());
         }
         return new ErrorResponse(
-                baseException.getErrorCode().getCode(),
-                baseException.getErrorCode().getMessage(),
-                baseException.getErrorCode().getDisplayType());
+                baseException.getCode().getCode(),
+                baseException.getCode().getMessage(),
+                baseException.getCode().getDisplayType());
     }
 }

--- a/src/main/java/com/arom/with_travel/global/jwt/error/TokenErrorCode.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/error/TokenErrorCode.java
@@ -1,0 +1,20 @@
+package com.arom.with_travel.global.jwt.error;
+
+import com.arom.with_travel.global.exception.error.BaseCode;
+import com.arom.with_travel.global.exception.error.ErrorDisplayType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TokenErrorCode implements BaseCode {
+
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND,"TKN-0000", "refresh token이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"TKN-0001", "유효하지 않은 token입니다.", ErrorDisplayType.POPUP);
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+    private final ErrorDisplayType displayType;
+}


### PR DESCRIPTION
# 이슈
- #40 

# 구현 기능


1. 도메인 별 책임 분리
- 각 도메인마다 ErrorCode를 만들고 BaseCode로 추상화함으로써 도메인 수준에서 책임을 위임했습니다.
- ErrorCode에 모든 에러를 몰아넣던 방식에 비해 응집도는 높이고 결합도는 낮췄습니다.

2. 확장성 향상
- 새로운 도메인이 생겨도 해당 도메인 전용 ErrorCode만 정의하면 되므로 기존 enum에 영향을 주지 않습니다.
- Open/Closed Principle (OCP)을 잘 따릅니다.

3. 통일된 예외 처리
- BaseException이 BaseCode에 의존하고 있으므로, 도메인 구분 없이 일관된 방식으로 예외를 처리할 수 있습니다.

4. 프론트와의 명확한 계약
- ErrorDisplayType으로 예외를 어떻게 UI에서 보여줄지도 명확히 표현할 수 있어 프론트와의 협업에 큰 도움이 됩니다.

