### PR TITLE
[feat] 로그인 후 신규 회원가입 기능 리팩토링 및 유저 검증 로직 추가

### DIFF
--- a/src/main/java/com/arom/with_travel/domain/member/controller/MemberSignupController.java
+++ b/src/main/java/com/arom/with_travel/domain/member/controller/MemberSignupController.java
@@ -4,65 +4,98 @@ import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.member.dto.MemberSignupRequestDto;
 import com.arom.with_travel.domain.member.dto.MemberSignupResponseDto;
 import com.arom.with_travel.domain.member.service.MemberSignupService;
+import com.arom.with_travel.domain.member.swagger.PostMemberSignup;
+import com.arom.with_travel.global.jwt.service.TokenProvider;
 import com.arom.with_travel.global.oauth2.dto.CustomOAuth2User;
-import io.swagger.v3.oas.annotations.Operation;
+import com.arom.with_travel.global.oauth2.handler.OAuth2SuccessHandler;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.Duration;
+
 @RestController
-@RequestMapping("/signup")
 @RequiredArgsConstructor
 @Tag(name = "회원가입", description = "사용자 회원가입 API")
 public class MemberSignupController {
 
     private final MemberSignupService memberSignupService;
+    private final TokenProvider tokenProvider;  // 토큰 검증용
 
-    @GetMapping("/check")
-    public ResponseEntity<?> checkUserRole(@AuthenticationPrincipal CustomOAuth2User customUser) {
+    @GetMapping("/signup")
+    public ResponseEntity<?> checkUserRole(
+            @CookieValue(name = OAuth2SuccessHandler.GUEST_TOKEN_COOKIE, required = false)
+            String guestToken,
+            HttpServletResponse response
+    ) {
 
-        if (customUser == null) {
+        if (guestToken == null) {
+            // 토큰 없이 왔으면 401
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
         }
 
-        if (customUser.getRole() == Member.Role.GUEST) {
-            return ResponseEntity.ok("GUEST; 추가 회원 가입이 필요합니다.");
-        } else {
-            return ResponseEntity.ok("USER; 이미 가입된 사용자입니다.");
+        // 토큰 검증, Authentication 세팅
+        Authentication auth = tokenProvider.getAuthentication(guestToken);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Object principal = auth.getPrincipal();
+        if (!(principal instanceof CustomOAuth2User)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body("잘못된 인증 정보입니다.");
         }
+
+        CustomOAuth2User customUser = (CustomOAuth2User) principal;
+
+        // 기존 회원이면
+        boolean exists = memberSignupService.existsByEmail(customUser.getEmail());
+        if (exists) {
+            Member m = memberSignupService.getByEmail(customUser.getEmail());
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .header("Location", "/home/" + m.getId())
+                    .build();
+        }
+
+        // 신규 GUEST면 추가정보 입력 페이지로
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header("Location", "/signup/register")
+                .build();
     }
 
-    @PostMapping("/register")
-    @Operation(summary = "회원 정보 등록", description = "신규 회원의 추가 정보를 저장합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원 정보 등록 성공"),
-            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음")
-    })
-    public MemberSignupResponseDto registerUser(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @RequestBody @Valid MemberSignupRequestDto requestDto
+    @GetMapping("/signup/register")
+    public String signupRegister() {
+        return "forward:/index.html";
+    }
+
+    @PostMapping("/signup/register")
+    @PostMemberSignup
+    public ResponseEntity<?> registerUser(
+            @CookieValue(name = OAuth2SuccessHandler.GUEST_TOKEN_COOKIE, required = false)
+            String guestToken,
+            @AuthenticationPrincipal CustomOAuth2User customUser,
+            @RequestBody @Valid MemberSignupRequestDto requestDto,
+            HttpServletResponse response
     ) {
-        if (customOAuth2User == null) {
-            throw new RuntimeException("로그인이 필요합니다.");
-        }
 
-        String email = customOAuth2User.getOAuth2Response().getEmail();
+        MemberSignupResponseDto savedMember = memberSignupService.registerMember(
+                customUser.getEmail(),
+                customUser.getOauthId(),
+                requestDto
+        );
 
-        Member member = memberSignupService.registerMember(email, requestDto);
+        // 가입 후 user용 JWT 발급
+        Member newMember = memberSignupService.getByEmail(customUser.getEmail());
+        String accessToken = tokenProvider.generateToken(newMember, Duration.ofDays(1));
+        response.setHeader("Authorization", "Bearer " + accessToken);
 
-        CustomOAuth2User newPrincipal = new CustomOAuth2User(customOAuth2User.getOAuth2Response(), Member.Role.USER);
-        UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(newPrincipal, null, newPrincipal.getAuthorities());
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        return MemberSignupResponseDto.from(member);
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header("Location", "/home/" + savedMember.getId())
+                .build();
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupRequestDto.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupRequestDto.java
@@ -1,10 +1,10 @@
 package com.arom.with_travel.domain.member.dto;
 
 import com.arom.with_travel.domain.member.Member.Gender;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,9 +20,9 @@ public class MemberSignupRequestDto {
     private String nickname;
 
     @NotNull(message = "생년월일을 입력해주세요.")
-    @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "생년월일은 yyyy-MM-dd 형식이어야 합니다.")
+    @JsonFormat(pattern = "yyyy-MM-dd")
     @Schema(description = "사용자 생년월일", example = "2003-05-30")
-    private LocalDate birthdate; // 생년월일 (yyyy-MM-dd)
+    private LocalDate birthdate;
 
     @NotNull(message = "성별을 선택해주세요.")
     @Schema(description = "사용자 성별 (MALE/FEMALE)", example = "MALE")

--- a/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupResponseDto.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupResponseDto.java
@@ -13,19 +13,19 @@ import java.time.LocalDate;
 @Schema(description = "회원가입 응답 DTO")
 public class MemberSignupResponseDto {
 
-    @Schema(description = "회원 ID", example = "1")
+    @Schema(example = "1")
     private Long id;
 
-    @Schema(description = "회원 이메일", example = "test@example.com")
+    @Schema(example = "test@example.com")
     private String email;
 
-    @Schema(description = "회원 닉네임", example = "피카츄")
+    @Schema(example = "피카츄")
     private String nickname;
 
-    @Schema(description = "회원 생년월일", example = "2003-05-30")
+    @Schema(example = "2003-05-30")
     private LocalDate birthdate;
 
-    @Schema(description = "회원 성별 (MALE/FEMALE)", example = "MALE")
+    @Schema(example = "MALE")
     private Gender gender;
 
     public static MemberSignupResponseDto from(Member member) {

--- a/src/main/java/com/arom/with_travel/domain/member/swagger/PostMemberSignup.java
+++ b/src/main/java/com/arom/with_travel/domain/member/swagger/PostMemberSignup.java
@@ -1,0 +1,26 @@
+package com.arom.with_travel.domain.member.swagger;
+
+import com.arom.with_travel.domain.member.dto.MemberSignupResponseDto;
+import com.arom.with_travel.global.exception.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(summary = "회원 정보 등록", description = "신규 회원의 추가 정보를 저장하고 홈 화면으로 리다이렉션 합니다.")
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "302", description = "회원 정보 등록 후 홈 화면으로 리다이렉션",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = MemberSignupResponseDto.class))),
+        @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음",
+                content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        schema = @Schema(implementation = ErrorResponse.class)))
+})
+public @interface PostMemberSignup {
+}

--- a/src/main/java/com/arom/with_travel/global/jwt/service/TokenProvider.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/service/TokenProvider.java
@@ -3,6 +3,8 @@ package com.arom.with_travel.global.jwt.service;
 import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.member.repository.MemberRepository;
 import com.arom.with_travel.global.jwt.config.JwtProperties;
+import com.arom.with_travel.global.oauth2.dto.CustomOAuth2User;
+import com.arom.with_travel.global.oauth2.dto.OAuth2Response;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
 import java.util.Set;
 
 @Service
@@ -60,19 +63,42 @@ public class TokenProvider {
         }
     }
 
-    // 토큰 인증정보 조회 메서드
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
-        Set<SimpleGrantedAuthority> authoritySet = Collections.singleton(
-                new SimpleGrantedAuthority(claims.get("role").toString()));
+        String email = claims.getSubject(); // subject = email
+        Member.Role role = Member.Role.valueOf(claims.get("role", String.class));
+
+        // 임시 OAuth2Response (필요한 정보만)
+        OAuth2Response stub = new OAuth2Response() {
+            @Override public Map<String, Object> getAttribute() { return Map.of(); }
+            @Override public String getOauthId()    { return null; }
+            @Override public String getProvider()   { return null; }
+            @Override public String getEmail()      { return email; }
+            @Override public String getName()       { return null; }
+        };
+
+        CustomOAuth2User principal = new CustomOAuth2User(stub, role, null);
 
         return new UsernamePasswordAuthenticationToken(
-                new org.springframework.security.core.userdetails.User(
-                        claims.getSubject(),
-                        "",
-                        authoritySet
-                ), token, authoritySet);
+                principal,
+                token,
+                principal.getAuthorities()
+        );
     }
+
+//    // 토큰 인증정보 조회 메서드
+//    public Authentication getAuthentication(String token) {
+//        Claims claims = getClaims(token);
+//        Set<SimpleGrantedAuthority> authoritySet = Collections.singleton(
+//                new SimpleGrantedAuthority(claims.get("role").toString()));
+//
+//        return new UsernamePasswordAuthenticationToken(
+//                new org.springframework.security.core.userdetails.User(
+//                        claims.getSubject(),
+//                        "",
+//                        authoritySet
+//                ), token, authoritySet);
+//    }
 
     // HttpServletRequest 에서 토큰을 파싱하여 로그인 이메일 반환
     public String getMemberLoginEmail(HttpServletRequest request) {

--- a/src/main/java/com/arom/with_travel/global/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/com/arom/with_travel/global/oauth2/dto/CustomOAuth2User.java
@@ -16,6 +16,7 @@ public class CustomOAuth2User implements OAuth2User {
 
     private final OAuth2Response oAuth2Response;
     private final Member.Role role;
+    private final String oauthId;
 
     @Override
     public Map<String, Object> getAttributes() {
@@ -38,4 +39,6 @@ public class CustomOAuth2User implements OAuth2User {
     public String getName() {
         return oAuth2Response.getName();
     }
+
+    public String getEmail() { return oAuth2Response.getEmail(); }
 }

--- a/src/main/java/com/arom/with_travel/global/oauth2/dto/KakaoResponse.java
+++ b/src/main/java/com/arom/with_travel/global/oauth2/dto/KakaoResponse.java
@@ -1,22 +1,28 @@
 package com.arom.with_travel.global.oauth2.dto;
 
 import lombok.extern.slf4j.Slf4j;
-
 import java.util.Map;
 
 // 차현철
 @Slf4j
 public class KakaoResponse implements OAuth2Response {
 
+    private final String oauthId;
     private final Map<String, Object> attribute;
 
-    public KakaoResponse(Map<String, Object> attribute) {
+    public KakaoResponse(String oauthId, Map<String, Object> attribute) {
+        this.oauthId = oauthId;
         this.attribute = (Map<String, Object>) attribute.get("kakao_account");
     }
 
     @Override
     public Map<String, Object> getAttribute() {
         return attribute;
+    }
+
+    @Override
+    public String getOauthId() {
+        return oauthId;
     }
 
     @Override
@@ -29,17 +35,19 @@ public class KakaoResponse implements OAuth2Response {
         if (attribute == null) {
             return null;
         }
-
-        return attribute.get("email").toString();
+        Object email = attribute.get("email");
+        return email != null ? email.toString() : null;
     }
+
     @Override
     public String getName() {
         if (attribute == null) {
             return null;
         }
-
         Map<String, Object> profile = (Map<String, Object>) attribute.get("profile");
-
-        return profile.get("nickname").toString();
+        if (profile != null && profile.get("nickname") != null) {
+            return profile.get("nickname").toString();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/arom/with_travel/global/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/com/arom/with_travel/global/oauth2/dto/OAuth2Response.java
@@ -9,4 +9,5 @@ public interface OAuth2Response {
     String getEmail(); //이메일
     String getName(); //사용자 실명 (설정한 이름)
     Map<String, Object> getAttribute();
+    String getOauthId();
 }

--- a/src/main/java/com/arom/with_travel/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/arom/with_travel/global/oauth2/service/CustomOAuth2UserService.java
@@ -30,14 +30,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         // 소셜로그인 인증 서버가 카카오인 경우.
         if (registrationId.equals("kakao")) {
-            oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
+            oAuth2Response = new KakaoResponse(oAuth2User.getAttributes().get("id").toString(),
+                    oAuth2User.getAttributes());
         }
 
-        String loginEmail = oAuth2Response.getEmail();
 
-        Member loginUser = memberRepository.findByEmail(loginEmail)
-                .orElse(Member.create(oAuth2Response.getName(), loginEmail, Member.Role.GUEST));
+        Member loginUser = memberRepository.findByEmail(oAuth2Response.getEmail())
+                .orElse(Member.create(oAuth2Response.getName(), oAuth2Response.getEmail(),
+                        Member.Role.GUEST));
 
-        return new CustomOAuth2User(oAuth2Response, Member.Role.GUEST);
+        return new CustomOAuth2User(oAuth2Response, Member.Role.GUEST, oAuth2Response.getOauthId());
     }
 }


### PR DESCRIPTION
# 이슈
- #29 

# 구현 기능
카카오 로그인 시 추가 정보와 함께 **신규 회원 등록 처리 구현 로직 수정** 
- GUEST로 리다이렉트한 유저에 대해 /signup 에서 **GUEST_TOKEN 기반 user 검증 추가** 
- 신규 회원 등록 (`/signup/register`) 엔드포인트 로직 흐름 추가 
- 회원 등록 시 oauthId 함께 저장  
- /signup/register POST swagger API 추가

# 작업 시간
