### PR TITLE
[test] 회원가입·인증 서비스 계층 단위 테스트 추가

### DIFF
--- a/src/test/java/com/arom/with_travel/domain/member/service/MemberSignupServiceTest.java
+++ b/src/test/java/com/arom/with_travel/domain/member/service/MemberSignupServiceTest.java
@@ -1,0 +1,94 @@
+package com.arom.with_travel.domain.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.dto.MemberSignupRequestDto;
+import com.arom.with_travel.domain.member.dto.MemberSignupResponseDto;
+import com.arom.with_travel.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static com.arom.with_travel.domain.member.Member.Gender.MALE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberSignupService 단위 테스트")
+class MemberSignupServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberSignupService memberSignupService;
+
+    private MemberSignupRequestDto 요청;
+    private Member 저장된회원;
+
+    @BeforeEach
+    void setUp() {
+        요청 = new MemberSignupRequestDto();
+        요청.setNickname("피카츄");
+        요청.setBirthdate(LocalDate.of(2003, 5, 30));
+        요청.setGender(MALE);
+
+        저장된회원 = Member.builder()
+                .id(1L)
+                .email("pikachu@kakao.com")
+                .nickname("피카츄")
+                .birth(요청.getBirthdate())
+                .gender(요청.getGender())
+                .oauthId("oauth123")
+                .loginType(Member.LoginType.KAKAO)
+                .role(Member.Role.USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 – DTO -> Entity 저장 후 응답 DTO 반환")
+    void 회원가입_성공() {
+        // given
+        given(memberRepository.save(any(Member.class))).willReturn(저장된회원);
+
+        // when
+        MemberSignupResponseDto 응답 =
+                memberSignupService.registerMember("pikachu@kakao.com", "oauth123", 요청);
+
+        // then
+        assertThat(응답.getId()).isEqualTo(1L);
+        assertThat(응답.getEmail()).isEqualTo("pikachu@kakao.com");
+        assertThat(응답.getNickname()).isEqualTo("피카츄");
+    }
+
+    @Test
+    @DisplayName("existsByEmail – 존재할 때 true")
+    void 이메일_존재_true() {
+        given(memberRepository.findByEmail("dup@kakao.com"))
+                .willReturn(Optional.of(저장된회원));
+
+        boolean result = memberSignupService.existsByEmail("dup@kakao.com");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByEmail – 없을 때 false")
+    void 이메일_존재_false() {
+        given(memberRepository.findByEmail("new@kakao.com"))
+                .willReturn(Optional.empty());
+
+        boolean result = memberSignupService.existsByEmail("new@kakao.com");
+
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/arom/with_travel/domain/member/service/MemberSignupServiceTest.java
+++ b/src/test/java/com/arom/with_travel/domain/member/service/MemberSignupServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+@SuppressWarnings("NonAsciiCharacters")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MemberSignupService 단위 테스트")
 class MemberSignupServiceTest {

--- a/src/test/java/com/arom/with_travel/domain/member/service/MemberSignupServiceTest.java
+++ b/src/test/java/com/arom/with_travel/domain/member/service/MemberSignupServiceTest.java
@@ -5,6 +5,8 @@ import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.member.dto.MemberSignupRequestDto;
 import com.arom.with_travel.domain.member.dto.MemberSignupResponseDto;
 import com.arom.with_travel.domain.member.repository.MemberRepository;
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import static com.arom.with_travel.domain.member.Member.Gender.MALE;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -68,6 +71,21 @@ class MemberSignupServiceTest {
         assertThat(응답.getId()).isEqualTo(1L);
         assertThat(응답.getEmail()).isEqualTo("pikachu@kakao.com");
         assertThat(응답.getNickname()).isEqualTo("피카츄");
+    }
+
+    @Test
+    @DisplayName("회원가입 중 저장 실패 시 예외 전파")
+    void 회원가입_실패_저장예외() {
+        // given
+        given(memberRepository.save(any(Member.class)))
+                .willThrow(BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() ->
+                memberSignupService.registerMember("pikachu@kakao.com", "oauth123", 요청)
+        )
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/com/arom/with_travel/global/jwt/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/arom/with_travel/global/jwt/service/RefreshTokenServiceTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("NonAsciiCharacters")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RefreshTokenService 단위 테스트")
 class RefreshTokenServiceTest {

--- a/src/test/java/com/arom/with_travel/global/jwt/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/arom/with_travel/global/jwt/service/RefreshTokenServiceTest.java
@@ -1,0 +1,54 @@
+package com.arom.with_travel.global.jwt.service;
+
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
+import com.arom.with_travel.global.jwt.domain.RefreshToken;
+import com.arom.with_travel.global.jwt.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefreshTokenService 단위 테스트")
+class RefreshTokenServiceTest {
+
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @InjectMocks RefreshTokenService refreshTokenService;
+
+    @Test
+    @DisplayName("findByRefreshToken – 존재 시 객체 반환")
+    void 토큰_조회_성공() {
+        // given
+        RefreshToken token = RefreshToken.create(1L, "refresh.jwt");
+        when(refreshTokenRepository.findByRefreshToken("refresh.jwt"))
+                .thenReturn(Optional.of(token));
+
+        // when
+        RefreshToken result = refreshTokenService.findByRefreshToken("refresh.jwt");
+
+        // then
+        assertThat(result).isEqualTo(token);
+    }
+
+    @Test
+    @DisplayName("findByRefreshToken – 없을 시 해당 ErrorCode 반환")
+    void 토큰_조회_실패_없음() {
+        // given
+        when(refreshTokenRepository.findByRefreshToken("none.jwt"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> refreshTokenService.findByRefreshToken("none.jwt"))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TOKEN_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
+++ b/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
@@ -1,0 +1,55 @@
+package com.arom.with_travel.global.jwt.service;
+
+import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.service.MemberSignupService;
+import com.arom.with_travel.global.jwt.domain.RefreshToken;
+import com.arom.with_travel.global.jwt.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TokenService 단위 테스트")
+class TokenServiceTest {
+
+    @Mock
+    TokenProvider tokenProvider;
+    @Mock
+    RefreshTokenService refreshTokenService;
+    @Mock MemberSignupService memberSignupService;
+    @Mock RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    TokenService tokenService;
+
+    @Test
+    @DisplayName("refresh 토큰으로 새 access 토큰 발급")
+    void 새_엑세스_토큰_발급() {
+        // given
+        String refreshToken = "refresh.jwt";
+
+        given(tokenProvider.validToken(refreshToken)).willReturn(true);
+
+        given(refreshTokenService.findByRefreshToken(refreshToken))
+                .willReturn(RefreshToken.create(1L, refreshToken));
+
+        Member member = Member.builder().id(1L).email("user@kakao.com").role(Member.Role.USER).build();
+        given(memberSignupService.getMemberByIdOrElseThrow(1L)).willReturn(member);
+
+        given(tokenProvider.generateToken(member, Duration.ofHours(2))).willReturn("newAccess.jwt");
+
+        // when
+        String result = tokenService.createNewAccessToken(refreshToken);
+
+        // then
+        assertThat(result).isEqualTo("newAccess.jwt");
+    }
+}

--- a/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
+++ b/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+@SuppressWarnings("NonAsciiCharacters")
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TokenService 단위 테스트")
 class TokenServiceTest {

--- a/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
+++ b/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
@@ -2,6 +2,8 @@ package com.arom.with_travel.global.jwt.service;
 
 import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.member.service.MemberSignupService;
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
 import com.arom.with_travel.global.jwt.domain.RefreshToken;
 import com.arom.with_travel.global.jwt.repository.RefreshTokenRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,5 +54,18 @@ class TokenServiceTest {
 
         // then
         assertThat(result).isEqualTo("newAccess.jwt");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 refresh 토큰이면 예외 발생")
+    void 엑세스_토큰_발급_실패_유효하지않음() {
+        // given
+        String invalidToken = "bad.jwt";
+        given(tokenProvider.validToken(invalidToken)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> tokenService.createNewAccessToken(invalidToken))
+                .isInstanceOf(BaseException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TOKEN);
     }
 }

--- a/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
+++ b/src/test/java/com/arom/with_travel/global/jwt/service/TokenServiceTest.java
@@ -29,7 +29,6 @@ class TokenServiceTest {
     @Mock
     RefreshTokenService refreshTokenService;
     @Mock MemberSignupService memberSignupService;
-    @Mock RefreshTokenRepository refreshTokenRepository;
 
     @InjectMocks
     TokenService tokenService;


### PR DESCRIPTION
# 이슈
- #63 

# 구현 기능
**1. MemberSignupService 단위 테스트 작성**
- registerMember() 정상 플로우 검증: DTO → Entity 변환 뒤 저장되고 MemberSignupResponseDto가 올바르게 반환되는지 확인
- existsByEmail() 중복 이메일 확인 true/false 시나리오 검증

**2. RefreshTokenService 단위 테스트 작성**
- 리프레시 토큰 존재 시 RefreshToken 객체 반환, 미존재 시 BaseException(ErrorCode.TOKEN_NOT_FOUND) 발생 여부 검증

**3. TokenService 단위 테스트 작성**
- createNewAccessToken() 흐름 검증:
  - 리프레시 토큰 유효성 체크 →
  - 토큰으로 사용자 조회 →
  - 새 access 토큰 발급 →
  - 발급된 토큰 값이 예상과 일치하는지 확인