### PR TITLE
[feat] 로그인 완료 후 회원 정보 조회시 Access · RefreshToken 반환 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-	//redis
+	// Redis / WebSocket / Mongo
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-
 
 	/* Swagger / OpenAPI */
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
@@ -81,23 +80,13 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	/* === 테스트 전용 === */
-	testImplementation 'org.springframework.boot:spring-boot-starter-test' // JUnit5 + Mockito(core) + AssertJ 포함
-	testImplementation 'org.springframework.security:spring-security-test'  // SecurityMockMvcRequestPostProcessors 등
-	testImplementation 'org.mockito:mockito-junit-jupiter'                 // MockitoExtension
-	testImplementation 'org.assertj:assertj-core'                          // 최신 AssertJ
-
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-	// security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-
-	// OAuth2
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
-	// jwt
-	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
+	testImplementation 'org.assertj:assertj-core'
+	testRuntimeOnly  'org.junit.platform:junit-platform-launcher'
 }
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/arom/with_travel/domain/member/controller/MemberSignupController.java
+++ b/src/main/java/com/arom/with_travel/domain/member/controller/MemberSignupController.java
@@ -1,13 +1,18 @@
 package com.arom.with_travel.domain.member.controller;
 
+import com.arom.with_travel.domain.member.dto.MemberSignupTokenResponse;
 import com.arom.with_travel.domain.member.dto.MemberSignupRequestDto;
 import com.arom.with_travel.domain.member.dto.MemberSignupResponseDto;
 import com.arom.with_travel.domain.member.service.MemberService;
 import com.arom.with_travel.domain.member.service.MemberSignupService;
+import com.arom.with_travel.global.jwt.dto.response.AuthTokenResponse;
+import com.arom.with_travel.global.jwt.service.TokenService;
 import com.arom.with_travel.global.oauth2.dto.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +24,7 @@ public class MemberSignupController {
 
     private final MemberService memberService;
     private final MemberSignupService memberSignupService;
+    private final TokenService tokenService;
 
     // 추가 정보 등록
     @PostMapping("/signup/register")
@@ -32,12 +38,16 @@ public class MemberSignupController {
     }
 
     // 현재 로그인 사용자 정보 조회
-    @GetMapping("/signup/register")
-    public ResponseEntity<MemberSignupResponseDto> getMyInfo(
-            @AuthenticationPrincipal CustomOAuth2User user) {
+    @GetMapping(value = "/signup/register",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<MemberSignupTokenResponse> getMyInfo(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            HttpServletResponse response) {
 
         MemberSignupResponseDto dto = memberSignupService
                 .getSignupInfo(user.getEmail());
-        return ResponseEntity.ok(dto);
+        AuthTokenResponse tokenDto = tokenService.issueTokenPair(user.getEmail(), response);
+        MemberSignupTokenResponse signupDto = new MemberSignupTokenResponse(dto, tokenDto.getAccessToken());
+        return ResponseEntity.ok(signupDto);
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/controller/MemberSignupController.java
+++ b/src/main/java/com/arom/with_travel/domain/member/controller/MemberSignupController.java
@@ -47,7 +47,7 @@ public class MemberSignupController {
         MemberSignupResponseDto dto = memberSignupService
                 .getSignupInfo(user.getEmail());
         AuthTokenResponse tokenDto = tokenService.issueTokenPair(user.getEmail(), response);
-        MemberSignupTokenResponse signupDto = new MemberSignupTokenResponse(dto, tokenDto.getAccessToken());
+        MemberSignupTokenResponse signupDto = new MemberSignupTokenResponse(dto, tokenDto);
         return ResponseEntity.ok(signupDto);
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
@@ -1,5 +1,7 @@
 package com.arom.with_travel.domain.member.dto;
 
+import com.arom.with_travel.global.jwt.dto.response.AuthTokenResponse;
+import com.nimbusds.oauth2.sdk.TokenResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,5 +11,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class MemberSignupTokenResponse {
     private MemberSignupResponseDto memberSignupDto;
-    private String accessToken;
+    private AuthTokenResponse tokenDto;
 }

--- a/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
@@ -1,7 +1,6 @@
 package com.arom.with_travel.domain.member.dto;
 
 import com.arom.with_travel.global.jwt.dto.response.AuthTokenResponse;
-import com.nimbusds.oauth2.sdk.TokenResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
@@ -4,10 +4,8 @@ import com.arom.with_travel.global.jwt.dto.response.AuthTokenResponse;
 import com.nimbusds.oauth2.sdk.TokenResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @AllArgsConstructor
 public class MemberSignupTokenResponse {
     private MemberSignupResponseDto memberSignupDto;

--- a/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/MemberSignupTokenResponse.java
@@ -1,0 +1,13 @@
+package com.arom.with_travel.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MemberSignupTokenResponse {
+    private MemberSignupResponseDto memberSignupDto;
+    private String accessToken;
+}

--- a/src/main/java/com/arom/with_travel/global/jwt/config/JwtProperties.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/config/JwtProperties.java
@@ -12,4 +12,7 @@ import org.springframework.stereotype.Component;
 public class JwtProperties {
     private String issuer;
     private String secretKey;
+    private int accessTokenExpireHours;
+    private int refreshTokenExpireDays;
+    private String refreshCookieName;
 }

--- a/src/main/java/com/arom/with_travel/global/jwt/dto/response/AuthTokenResponse.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/dto/response/AuthTokenResponse.java
@@ -9,4 +9,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class AuthTokenResponse {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/arom/with_travel/global/jwt/dto/response/AuthTokenResponse.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/dto/response/AuthTokenResponse.java
@@ -1,0 +1,12 @@
+package com.arom.with_travel.global.jwt.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AuthTokenResponse {
+    private String accessToken;
+}

--- a/src/main/java/com/arom/with_travel/global/jwt/dto/response/AuthTokenResponse.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/dto/response/AuthTokenResponse.java
@@ -2,10 +2,9 @@ package com.arom.with_travel.global.jwt.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
+
 
 @Getter
-@Setter
 @AllArgsConstructor
 public class AuthTokenResponse {
     private String accessToken;

--- a/src/main/java/com/arom/with_travel/global/jwt/service/TokenService.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/service/TokenService.java
@@ -79,6 +79,6 @@ public class TokenService {
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-        return new AuthTokenResponse(accessToken);
+        return new AuthTokenResponse(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/arom/with_travel/global/jwt/service/TokenService.java
+++ b/src/main/java/com/arom/with_travel/global/jwt/service/TokenService.java
@@ -2,14 +2,18 @@ package com.arom.with_travel.global.jwt.service;
 
 import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.member.service.MemberService;
-import com.arom.with_travel.domain.member.service.MemberSignupService;
 import com.arom.with_travel.global.exception.BaseException;
 import com.arom.with_travel.global.exception.error.ErrorCode;
+import com.arom.with_travel.global.jwt.config.JwtProperties;
 import com.arom.with_travel.global.jwt.domain.RefreshToken;
+import com.arom.with_travel.global.jwt.dto.response.AuthTokenResponse;
 import com.arom.with_travel.global.jwt.repository.RefreshTokenRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -24,7 +28,7 @@ public class TokenService {
     private final RefreshTokenService refreshTokenService;
     private final MemberService memberService;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final MemberSignupService memberSignupService;
+    private final JwtProperties jwtProperties;
 
     // 새로운 액세스 토큰 생성
     public String createNewAccessToken(String refreshToken) {
@@ -50,5 +54,31 @@ public class TokenService {
         if (!tokenProvider.validToken(refreshToken)) {
             throw BaseException.from(ErrorCode.INVALID_TOKEN);
         }
+    }
+
+    public AuthTokenResponse issueTokenPair(String loginEmail, HttpServletResponse response) {
+
+        Member member = memberService.getUserByLoginEmailOrElseThrow(loginEmail);
+
+        String accessToken = tokenProvider.generateToken(
+                member,
+                Duration.ofHours(jwtProperties.getAccessTokenExpireHours())
+        );
+
+        String refreshToken = tokenProvider.generateToken(
+                member,
+                Duration.ofDays(jwtProperties.getRefreshTokenExpireDays())
+        );
+
+        // HttpOnly 쿠키 설정
+        ResponseCookie cookie = ResponseCookie.from(jwtProperties.getRefreshCookieName(), refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofDays(jwtProperties.getRefreshTokenExpireDays()))
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return new AuthTokenResponse(accessToken);
     }
 }


### PR DESCRIPTION
# 이슈
- #64 

# 구현 기능
**로그인 직후 /signup/register 엔드포인트에서 AccessToken과 RefreshToken을 회원 정보와 함께 반환하도록 동작 수정**

1. **AccessToken** **response body** 로 전달

프론트에서 로그인처리에 사용할 수 있도록 로그인 직후 `AccessToken`을 발급하여 회원 정보와 함께 `response body에 포함`하여 반환합니다.

2. **RefreshToken**은 **HttpOnly 쿠키**로 전달

RefreshToken은 AccessToken보다 유효기간이 길어 `탈취로 인한 보안 위험이 존재`합니다.
따라서 브라우저의 JavaScript에서 접근이 불가능한 `HttpOnly 쿠키`로 전달하도록 변경하여 XSS 공격을 대비하였습니다. 