### PR TITLE
[feat] 여행 정보 community 게시물 및 댓글 관련 서비스 구현 

### DIFF
--- a/src/main/java/com/arom/with_travel/domain/community/Community.java
+++ b/src/main/java/com/arom/with_travel/domain/community/Community.java
@@ -6,9 +6,7 @@ import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
@@ -18,6 +16,8 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 @SQLDelete(sql = "UPDATE community SET is_deleted = true, deleted_at = now() where id = ?")
 @SQLRestriction("is_deleted is FALSE")
 public class Community extends BaseEntity {
@@ -25,23 +25,19 @@ public class Community extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @NotNull
+
+    @NotNull @Column(length = 120)
     private String title;
 
-    @NotNull
+    @NotNull @Lob
     private String content;
 
-    @NotNull
-    private String continent;
-
-    @NotNull
-    private String country;
-
-    @NotNull
-    private String city;
+    @NotNull private String continent;
+    @NotNull private String country;
+    @NotNull private String city;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @OneToMany(mappedBy = "community")
@@ -49,4 +45,28 @@ public class Community extends BaseEntity {
 
     @OneToMany(mappedBy = "community")
     private List<Image> images = new ArrayList<>();
+
+    @Column(nullable = false)
+    private long viewCount = 0L;
+
+    public static Community create(Member writer, String title, String content,
+                                   String continent, String country, String city) {
+        Community c = Community.builder()
+                .member(writer)
+                .title(title)
+                .content(content)
+                .continent(continent)
+                .country(country)
+                .city(city)
+                .build();
+        return c;
+    }
+
+    public void update(String title, String content, String continent, String country, String city) {
+        if (title != null) this.title = title;
+        if (content != null) this.content = content;
+        if (continent != null) this.continent = continent;
+        if (country != null) this.country = country;
+        if (city != null) this.city = city;
+    }
 }

--- a/src/main/java/com/arom/with_travel/domain/community/CommunitySpecs.java
+++ b/src/main/java/com/arom/with_travel/domain/community/CommunitySpecs.java
@@ -1,0 +1,31 @@
+package com.arom.with_travel.domain.community;
+
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.util.StringUtils;
+
+public class CommunitySpecs {
+    private CommunitySpecs() {}
+
+    public static Specification<Community> continentEq(String continent) {
+        return (root, q, cb) -> StringUtils.hasText(continent) ? cb.equal(root.get("continent"), continent) : null;
+    }
+
+    public static Specification<Community> countryEq(String country) {
+        return (root, q, cb) -> StringUtils.hasText(country) ? cb.equal(root.get("country"), country) : null;
+    }
+
+    public static Specification<Community> cityEq(String city) {
+        return (root, q, cb) -> StringUtils.hasText(city) ? cb.equal(root.get("city"), city) : null;
+    }
+
+    public static Specification<Community> keywordLike(String qword) {
+        return (root, q, cb) -> {
+            if (!StringUtils.hasText(qword)) return null;
+            String like = "%" + qword.trim() + "%";
+            return cb.or(
+                    cb.like(root.get("title"), like),
+                    cb.like(root.get("content"), like)
+            );
+        };
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/arom/with_travel/domain/community/controller/CommunityController.java
@@ -1,0 +1,62 @@
+package com.arom.with_travel.domain.community.controller;
+
+import com.arom.with_travel.domain.community.dto.CommunityCreateRequest;
+import com.arom.with_travel.domain.community.dto.CommunityDetailResponse;
+import com.arom.with_travel.domain.community.dto.CommunityListItemResponse;
+import com.arom.with_travel.domain.community.dto.CommunityUpdateRequest;
+import com.arom.with_travel.domain.community.service.CommunityService;
+import com.arom.with_travel.global.security.domain.PrincipalDetails;
+import com.arom.with_travel.global.utils.SecurityUtils;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/communities")
+public class CommunityController {
+
+    private final CommunityService communityService;
+
+    @PostMapping
+    public Long create(@AuthenticationPrincipal PrincipalDetails principal,
+                       @RequestBody @Valid CommunityCreateRequest req) {
+        String me = principal.getAuthenticatedMember().getEmail();
+        return communityService.create(me, req);
+    }
+
+    @GetMapping("/{id}")
+    public CommunityDetailResponse detail(@PathVariable Long id) {
+        return communityService.readAndIncreaseView(id);
+    }
+
+    @GetMapping
+    public Page<CommunityListItemResponse> list(
+            @RequestParam(required = false) String continent,
+            @RequestParam(required = false) String country,
+            @RequestParam(required = false) String city,
+            @RequestParam(required = false, name = "q") String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return communityService.search(continent, country, city, keyword, pageable);
+    }
+
+    @PatchMapping("/{id}")
+    public void update(@PathVariable Long id, @RequestBody @Valid CommunityUpdateRequest req) {
+        Long me = SecurityUtils.currentMemberIdOrThrow();
+        communityService.update(me, id, req);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        Long me = SecurityUtils.currentMemberIdOrThrow();
+        communityService.delete(me, id);
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityCreateRequest.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityCreateRequest.java
@@ -1,0 +1,29 @@
+package com.arom.with_travel.domain.community.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityCreateRequest {
+    @NotEmpty @Size(max = 120) String title;
+    @NotEmpty String content;
+    @NotEmpty String continent;
+    @NotEmpty String country;
+    @NotEmpty String city;
+    private List<ImageCreate> images;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ImageCreate {
+        private String imageName;
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponse.java
@@ -21,5 +21,5 @@ public class CommunityDetailResponse {
     long viewCount;
     List<String> imageUrls;
     String createdAt;
-    String updatedA;
+    String updatedAt;
 }

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponse.java
@@ -1,0 +1,25 @@
+package com.arom.with_travel.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityDetailResponse {
+    Long id;
+    String title;
+    String content;
+    String continent;
+    String country;
+    String city;
+    Long writerId;
+    String writerNickname;
+    long viewCount;
+    List<String> imageUrls;
+    String createdAt;
+    String updatedA;
+}

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityListItemResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityListItemResponse.java
@@ -1,0 +1,21 @@
+package com.arom.with_travel.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityListItemResponse {
+    Long id;
+    String title;
+    String snippet;
+    String continent;
+    String country;
+    String city;
+    Long writerId;
+    String writerNickname;
+    long viewCount;
+    String createdAt;
+}

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityUpdateRequest.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityUpdateRequest.java
@@ -1,0 +1,27 @@
+package com.arom.with_travel.domain.community.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityUpdateRequest {
+    private String title;
+    private String content;
+    private String continent;
+    private String country;
+    private String city;
+    private List<ImageUpdate> images;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ImageUpdate {
+        private String imageName;
+        private String imageUrl;
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community/repository/CommunityRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/community/repository/CommunityRepository.java
@@ -1,0 +1,23 @@
+package com.arom.with_travel.domain.community.repository;
+
+import com.arom.with_travel.domain.community.Community;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.*;
+
+public interface CommunityRepository extends JpaRepository<Community, Long>,
+        JpaSpecificationExecutor<Community> {
+
+    @EntityGraph(attributePaths = {"member", "images"})
+    @Query("select c from Community c where c.id = :id")
+    Community findDetailById(Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Community c set c.viewCount = c.viewCount + 1 where c.id = :id")
+    int increaseViewCount(Long id);
+
+    default Page<Community> search(Specification<Community> spec, Pageable pageable) {
+        return this.findAll(spec, pageable);
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
+++ b/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
@@ -114,6 +114,28 @@ public class CommunityService {
         communityRepository.delete(c);
     }
 
+    @Transactional
+    public Page<CommunityListItemResponse> search(String continent, String country, String city, String q,
+                                                  Pageable pageable) {
+        Specification<Community> spec = Specification
+                .where(continentEq(continent))
+                .and(countryEq(country))
+                .and(cityEq(city))
+                .and(keywordLike(q));
+
+        return communityRepository.search(spec, pageable)
+                .map(c -> new CommunityListItemResponse(
+                        c.getId(),
+                        c.getTitle(),
+                        c.getContent().length() > 30 ? c.getContent().substring(0, 30) + "..." : c.getContent(),
+                        c.getContinent(), c.getCountry(), c.getCity(),
+                        c.getMember().getId(),
+                        c.getMember().getNickname(),
+                        c.getViewCount(),
+                        c.getCreatedAt().toString()
+                ));
+    }
+
     private void validateOwnership(Long currentMemberId, Long ownerId) {
         if (!ownerId.equals(currentMemberId)) {
             throw BaseException.from(ErrorCode.COMMUNITY_FORBIDDEN);

--- a/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
+++ b/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
@@ -109,7 +109,7 @@ public class CommunityService {
     @Transactional
     public void delete(Long currentMemberId, Long communityId) {
         Community c = communityRepository.findById(communityId)
-                .orElseThrow(() -> BaseException.from(ErrorCode.CONTINENT_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND));
         validateOwnership(currentMemberId, c.getMember().getId());
         communityRepository.delete(c);
     }

--- a/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
+++ b/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
@@ -1,0 +1,122 @@
+package com.arom.with_travel.domain.community.service;
+
+import com.arom.with_travel.domain.community.Community;
+import com.arom.with_travel.domain.community.dto.CommunityCreateRequest;
+import com.arom.with_travel.domain.community.dto.CommunityDetailResponse;
+import com.arom.with_travel.domain.community.dto.CommunityListItemResponse;
+import com.arom.with_travel.domain.community.dto.CommunityUpdateRequest;
+import com.arom.with_travel.domain.community.repository.CommunityRepository;
+import com.arom.with_travel.domain.image.Image;
+import com.arom.with_travel.domain.image.repository.ImageRepository;
+import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.repository.MemberRepository;
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.arom.with_travel.domain.community.CommunitySpecs.*;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityService {
+
+    private final CommunityRepository communityRepository;
+    private final MemberRepository memberRepository;
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public Long create(String currentMemberEmail, CommunityCreateRequest req) {
+        Member writer = memberRepository.findByEmail(currentMemberEmail)
+                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+
+        Community saved = communityRepository.save(
+                Community.create(writer, req.getTitle(), req.getContent(),
+                        req.getContinent(), req.getCountry(), req.getCity())
+        );
+
+        if (req.getImages() != null) {
+            List<Image> newImages = req.getImages().stream()
+                    .map(img -> Image.fromCommunity(
+                            defaultName(img.getImageName()),
+                            requireUrl(img.getImageUrl()),
+                            saved
+                    ))
+                    .toList();
+            if (!newImages.isEmpty()) imageRepository.saveAll(newImages);
+        }
+        return saved.getId();
+    }
+
+    private static String defaultName(String name) {
+        return (name == null || name.isBlank())
+                ? java.util.UUID.randomUUID().toString()
+                : name;
+    }
+
+    private static String requireUrl(String url) {
+        if (url == null || url.isBlank()) {
+            throw BaseException.from(ErrorCode.IMG_URL_MUST_FILLED);
+        }
+        return url;
+    }
+
+    @Transactional
+    public CommunityDetailResponse readAndIncreaseView(Long id) {
+        communityRepository.increaseViewCount(id);
+        Community c = communityRepository.findDetailById(id);
+        if (c == null) throw BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND);
+        List<String> urls = c.getImages().stream().map(Image::getImageUrl).collect(Collectors.toList());
+        return new CommunityDetailResponse(
+                c.getId(), c.getTitle(), c.getContent(),
+                c.getContinent(), c.getCountry(), c.getCity(),
+                c.getMember().getId(), c.getMember().getNickname(),
+                c.getViewCount(), urls,
+                c.getCreatedAt().toString(), c.getUpdatedAt().toString()
+        );
+    }
+
+    @Transactional
+    public void update(Long currentMemberId, Long communityId, CommunityUpdateRequest req) {
+        Community c = communityRepository.findById(communityId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND));
+        validateOwnership(currentMemberId, c.getMember().getId());
+
+        c.update(req.getTitle(), req.getContent(), req.getContinent(), req.getCountry(), req.getCity());
+
+        if (req.getImages() != null) {
+            c.getImages().forEach(Image::detachFromCommunity);
+
+            List<Image> newImages = req.getImages().stream()
+                    .map(img -> Image.fromCommunity(
+                            defaultName(img.getImageName()),
+                            requireUrl(img.getImageUrl()),
+                            c
+                    ))
+                    .toList();
+
+            if (!newImages.isEmpty()) imageRepository.saveAll(newImages);
+        }
+    }
+
+    @Transactional
+    public void delete(Long currentMemberId, Long communityId) {
+        Community c = communityRepository.findById(communityId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.CONTINENT_NOT_FOUND));
+        validateOwnership(currentMemberId, c.getMember().getId());
+        communityRepository.delete(c);
+    }
+
+    private void validateOwnership(Long currentMemberId, Long ownerId) {
+        if (!ownerId.equals(currentMemberId)) {
+            throw BaseException.from(ErrorCode.COMMUNITY_FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReply.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReply.java
@@ -5,15 +5,15 @@ import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 @SQLDelete(sql = "UPDATE community_reply SET is_deleted = true, deleted_at = now() where id = ?")
 @SQLRestriction("is_deleted is FALSE")
 public class CommunityReply extends BaseEntity {
@@ -26,12 +26,24 @@ public class CommunityReply extends BaseEntity {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "community_id")
+    @JoinColumn(name = "community_id", nullable = false)
     private Community community;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public static CommunityReply create(Community community, Member writer, String content) {
+        return CommunityReply.builder()
+                .community(community)
+                .member(writer)
+                .content(content)
+                .build();
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
 
 
 }

--- a/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReplyLike.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReplyLike.java
@@ -1,0 +1,28 @@
+package com.arom.with_travel.domain.community_reply;
+
+import com.arom.with_travel.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CommunityReplyLike {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_id", nullable = false)
+    private CommunityReply reply;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public static CommunityReplyLike of(CommunityReply reply, Member member) {
+        return CommunityReplyLike.builder().reply(reply).member(member).build();
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/controller/CommunityReplyController.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/controller/CommunityReplyController.java
@@ -1,0 +1,68 @@
+package com.arom.with_travel.domain.community_reply.controller;
+
+import com.arom.with_travel.domain.community_reply.dto.ReplyCreateRequest;
+import com.arom.with_travel.domain.community_reply.dto.ReplyResponse;
+import com.arom.with_travel.domain.community_reply.dto.ReplyUpdateRequest;
+import com.arom.with_travel.domain.community_reply.service.CommunityReplyService;
+import com.arom.with_travel.global.utils.SecurityUtils;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class CommunityReplyController {
+
+    private final CommunityReplyService replyService;
+
+    @PostMapping("/communities/{communityId}/replies")
+    public Long write(@PathVariable Long communityId, @RequestBody @Valid ReplyCreateRequest req) {
+        Long me = SecurityUtils.currentMemberIdOrThrow();
+        return replyService.write(me, communityId, req);
+    }
+
+    @GetMapping("/communities/{communityId}/replies")
+    public Slice<ReplyResponse> list(
+            @PathVariable Long communityId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+
+        Long me = null;
+        try { me = SecurityUtils.currentMemberIdOrThrow(); } catch (Exception ignore) {}
+
+        int MAX_SIZE = 100;
+        int safeSize = Math.min(size, MAX_SIZE);
+
+        Pageable pageable = PageRequest.of(page, safeSize, Sort.by(Sort.Direction.ASC, "createdAt"));
+        return replyService.listSlice(me, communityId, pageable);
+    }
+
+    @PatchMapping("/replies/{replyId}")
+    public void update(@PathVariable Long replyId, @RequestBody @Valid ReplyUpdateRequest req) {
+        Long me = SecurityUtils.currentMemberIdOrThrow();
+        replyService.update(me, replyId, req);
+    }
+
+    @DeleteMapping("/replies/{replyId}")
+    public void delete(@PathVariable Long replyId) {
+        Long me = SecurityUtils.currentMemberIdOrThrow();
+        replyService.delete(me, replyId);
+    }
+
+    @PostMapping("/replies/{replyId}/likes")
+    public void like(@PathVariable Long replyId) {
+        Long me = SecurityUtils.currentMemberIdOrThrow();
+        replyService.like(me, replyId);
+    }
+
+    @DeleteMapping("/replies/{replyId}/likes")
+    public void unlike(@PathVariable Long replyId) {
+        Long me = SecurityUtils.currentMemberIdOrThrow();
+        replyService.unlike(me, replyId);
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/dto/ReplyCreateRequest.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/dto/ReplyCreateRequest.java
@@ -1,0 +1,13 @@
+package com.arom.with_travel.domain.community_reply.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReplyCreateRequest {
+    @NotBlank private String content;
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/dto/ReplyResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/dto/ReplyResponse.java
@@ -1,0 +1,18 @@
+package com.arom.with_travel.domain.community_reply.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReplyResponse {
+    Long id;
+    Long memberId;
+    String memberNickname;
+    String content;
+    long likeCount;
+    boolean likedByMe;
+    String createdAt;
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/dto/ReplyUpdateRequest.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/dto/ReplyUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.arom.with_travel.domain.community_reply.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReplyUpdateRequest {
+    @NotBlank private String content;
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/repository/CommunityReplyLikeRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/repository/CommunityReplyLikeRepository.java
@@ -1,0 +1,10 @@
+package com.arom.with_travel.domain.community_reply.repository;
+
+import com.arom.with_travel.domain.community_reply.CommunityReplyLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityReplyLikeRepository extends JpaRepository<CommunityReplyLike, Long> {
+    boolean existsByReplyIdAndMemberId(Long replyId, Long memberId);
+    long countByReplyId(Long replyId);
+    void deleteByReplyIdAndMemberId(Long replyId, Long memberId);
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/repository/CommunityReplyRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/repository/CommunityReplyRepository.java
@@ -1,0 +1,16 @@
+package com.arom.with_travel.domain.community_reply.repository;
+
+import com.arom.with_travel.domain.community.Community;
+import com.arom.with_travel.domain.community_reply.CommunityReply;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommunityReplyRepository extends JpaRepository<CommunityReply, Long> {
+
+    @EntityGraph(attributePaths = {"member"})
+    Page<CommunityReply> findByCommunity(Community community, Pageable pageable);
+    Slice<CommunityReply> findByCommunityOrderByCreatedAtAsc(Community community, Pageable pageable);
+}

--- a/src/main/java/com/arom/with_travel/domain/community_reply/service/CommunityReplyService.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/service/CommunityReplyService.java
@@ -1,0 +1,94 @@
+package com.arom.with_travel.domain.community_reply.service;
+
+import com.arom.with_travel.domain.community.Community;
+import com.arom.with_travel.domain.community.repository.CommunityRepository;
+import com.arom.with_travel.domain.community_reply.CommunityReply;
+import com.arom.with_travel.domain.community_reply.CommunityReplyLike;
+import com.arom.with_travel.domain.community_reply.dto.ReplyCreateRequest;
+import com.arom.with_travel.domain.community_reply.dto.ReplyResponse;
+import com.arom.with_travel.domain.community_reply.dto.ReplyUpdateRequest;
+import com.arom.with_travel.domain.community_reply.repository.CommunityReplyLikeRepository;
+import com.arom.with_travel.domain.community_reply.repository.CommunityReplyRepository;
+import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.repository.MemberRepository;
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityReplyService {
+    private final CommunityRepository communityRepository;
+    private final CommunityReplyRepository replyRepository;
+    private final CommunityReplyLikeRepository likeRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long write(Long currentMemberId, Long communityId, ReplyCreateRequest req) {
+        Member writer = memberRepository.findById(currentMemberId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND));
+
+        CommunityReply saved = replyRepository.save(CommunityReply.create(community, writer, req.getContent()));
+        return saved.getId();
+    }
+
+    @Transactional
+    public void update(Long currentMemberId, Long replyId, ReplyUpdateRequest req) {
+        CommunityReply reply = replyRepository.findById(replyId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.REPLY_NOT_FOUND));
+        if (!reply.getMember().getId().equals(currentMemberId)) {
+            throw BaseException.from(ErrorCode.REPLY_FORBIDDEN);
+        }
+        reply.changeContent(req.getContent());
+    }
+
+    @Transactional
+    public void delete(Long currentMemberId, Long replyId) {
+        CommunityReply reply = replyRepository.findById(replyId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.REPLY_NOT_FOUND));
+        if (!reply.getMember().getId().equals(currentMemberId)) {
+            throw BaseException.from(ErrorCode.REPLY_FORBIDDEN);
+        }
+        replyRepository.delete(reply);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<ReplyResponse> listSlice(Long currentMemberIdOrNull, Long communityId, Pageable pageable) {
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND));
+
+        return replyRepository.findByCommunityOrderByCreatedAtAsc(community, pageable)
+                .map(r -> new ReplyResponse(
+                        r.getId(),
+                        r.getMember().getId(),
+                        r.getMember().getNickname(),
+                        r.getContent(),
+                        likeRepository.countByReplyId(r.getId()),
+                        currentMemberIdOrNull != null &&
+                        likeRepository.existsByReplyIdAndMemberId(r.getId(), currentMemberIdOrNull),
+                        r.getCreatedAt().toString()
+                ));
+    }
+
+    @Transactional
+    public void like(Long currentMemberId, Long replyId) {
+        CommunityReply reply = replyRepository.findById(replyId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.REPLY_NOT_FOUND));
+        if (!likeRepository.existsByReplyIdAndMemberId(replyId, currentMemberId)) {
+            Member me = memberRepository.findById(currentMemberId)
+                    .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+            likeRepository.save(CommunityReplyLike.of(reply, me));
+        }
+    }
+
+    @Transactional
+    public void unlike(Long currentMemberId, Long replyId) {
+        likeRepository.deleteByReplyIdAndMemberId(replyId, currentMemberId);
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/image/Image.java
+++ b/src/main/java/com/arom/with_travel/domain/image/Image.java
@@ -74,4 +74,7 @@ public class Image extends BaseEntity {
     public static Image fromCommunity(String imageName, String imageUrl, Community community) {
         return new Image(imageName, imageUrl, community, ImageType.COMMUNITY);
     }
+
+    public void attachToCommunity(Community c) { this.community = c; }
+    public void detachFromCommunity() { this.community = null; }
 }

--- a/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
@@ -58,6 +58,16 @@ public enum ErrorCode {
 
     // image
     INVALID_IMG_TYPE("IMG-0000", "지원하지 않는 이미지 형식입니다.", ErrorDisplayType.POPUP),
+    IMG_URL_MUST_FILLED("IMG-0001", "이미지 url이 존재해야합니다.", ErrorDisplayType.POPUP),
+
+    // community
+    CONTINENT_NOT_FOUND("COM-0000", "해당 대륙이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    COMMUNITY_NOT_FOUND("CON-0001", "해당 커뮤니티 게시글이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    COMMUNITY_FORBIDDEN("CON-0002", "해당 게시글의 수정 및 삭제 권한이 없습니다.", ErrorDisplayType.POPUP),
+
+    // reply
+    REPLY_NOT_FOUND("REP-0000", "해당 댓글이 존재하지 않습니다.", ErrorDisplayType.POPUP),
+    REPLY_FORBIDDEN("REP-0001", "해당 댓글에 수정 및 삭제 권한이 없습니다.", ErrorDisplayType.POPUP)
     ;
 
     private final String code;

--- a/src/main/java/com/arom/with_travel/global/utils/SecurityUtils.java
+++ b/src/main/java/com/arom/with_travel/global/utils/SecurityUtils.java
@@ -1,0 +1,24 @@
+package com.arom.with_travel.global.utils;
+
+import com.arom.with_travel.global.security.domain.AuthenticatedMember;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public final class SecurityUtils {
+
+    private SecurityUtils() {}
+
+    public static Long currentMemberIdOrThrow() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new IllegalStateException("Unauthenticated");
+        }
+        Object principal = auth.getPrincipal();
+
+        if (principal instanceof AuthenticatedMember authenticatedMember) {
+            return authenticatedMember.getMemberId();
+        }
+
+        throw new IllegalStateException("Unsupported principal: " + principal);
+    }
+}


### PR DESCRIPTION
# 이슈
- #102 

# 구현 기능
- 커뮤니티 게시글 CRUD
  - 여행 정보 커뮤니티 게시글 작성, 수정, 삭제, 조회 기능 구현
  - 게시글 작성자만 수정 가능하도록 검사하여 수정 및 삭제 권한 부여
  - 게시글 조회 시 대륙/국가/도시/키워드 검색 조건을 기반으로 Specification 활용하여 동적 쿼리 처리
  - 페이징(Page) 방식으로 게시글 목록 조회

- 커뮤니티 댓글 CRUD
  - 특정 게시글에 대한 댓글 작성, 수정, 삭제, 조회 기능 구현
  - 댓글 목록 조회 시 Slice 기반 무한 스크롤 방식 적용

- 댓글 좋아요 기능
  - 댓글에 좋아요(Like) 등록 및 취소 기능 구현
  - 동일 회원이 중복 좋아요를 할 수 없도록 제약 처리

# 구현 근거

- 검색 기능 (Specification)
  - 검색 조건(대륙, 국가, 도시, 키워드)을 조합해 동적으로 SQL WHERE 절을 생성
  - 필요 없는 조건은 자동으로 무시되므로 불필요한 쿼리 복잡도 감소

- 게시글 조회 (Page)
  - 게시판의 특성상 전체 데이터 개수와 페이지 수를 알아야 하는 경우가 많음 → Page 객체로 구현하여 총 게시글 수 및 페이지 메타데이터 제공
  - 리스트 단순 조회보다 정렬, 페이지네이션, 전체 개수 조회 측면에서 유리

- 댓글 조회 (Slice)
  - 댓글은 게시글보다 상대적으로 데이터가 많고 계속 추가되는 특성이 강함
  - 무한 스크롤 UX에 적합하도록 Slice 적용 → hasNext 여부만 조회하여 성능 최적화 (count 쿼리 생략)

- 좋아요 기능
  - 댓글 활성화와 커뮤니티 몰입도 증가
  - exists 쿼리를 활용하여 불필요한 좋아요 insert 중복을 방지