### PR TITLE
[feat] 회원가입 필드 추가 및 커뮤니티 로직/연관관계 개선

### DIFF
--- a/src/main/java/com/arom/with_travel/domain/community/Community.java
+++ b/src/main/java/com/arom/with_travel/domain/community/Community.java
@@ -75,10 +75,10 @@ public class Community extends BaseEntity {
 
 
     public void update(String title, String content, String continent, String country, String city) {
-        if (title != null) this.title = title;
-        if (content != null) this.content = content;
-        if (continent != null) this.continent = continent;
-        if (country != null) this.country = country;
-        if (city != null) this.city = city;
+        this.title = title;
+        this.content = content;
+        this.continent = continent;
+        this.country = country;
+        this.city = city;
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/community/Community.java
+++ b/src/main/java/com/arom/with_travel/domain/community/Community.java
@@ -40,7 +40,7 @@ public class Community extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToMany(mappedBy = "community")
+    @OneToMany(mappedBy = "community", orphanRemoval = true)
     private List<CommunityReply> communityReplies = new ArrayList<>();
 
     @OneToMany(mappedBy = "community")
@@ -73,6 +73,12 @@ public class Community extends BaseEntity {
         }
     }
 
+    public void addReply(CommunityReply reply) {
+        this.communityReplies.add(reply);
+        if (reply.getCommunity() != this) {
+            reply.setCommunity(this);
+        }
+    }
 
     public void update(String title, String content, String continent, String country, String city) {
         this.title = title;

--- a/src/main/java/com/arom/with_travel/domain/community/Community.java
+++ b/src/main/java/com/arom/with_travel/domain/community/Community.java
@@ -59,8 +59,20 @@ public class Community extends BaseEntity {
                 .country(country)
                 .city(city)
                 .build();
+        c.changeMember(writer);
         return c;
     }
+
+    public void changeMember(Member newMember) {
+        if (this.member != null) {
+            this.member.getCommunities().remove(this);
+        }
+        this.member = newMember;
+        if (newMember != null && !newMember.getCommunities().contains(this)) {
+            newMember.getCommunities().add(this);
+        }
+    }
+
 
     public void update(String title, String content, String continent, String country, String city) {
         if (title != null) this.title = title;

--- a/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
+++ b/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
@@ -70,10 +70,17 @@ public class CommunityService {
 
     @Transactional
     public CommunityDetailResponse readAndIncreaseView(Long id) {
-        communityRepository.increaseViewCount(id);
+        if (!communityRepository.existsById(id)) {
+            throw BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND);
+        }
+
+        int updated = communityRepository.increaseViewCount(id);
+
         Community c = communityRepository.findDetailById(id);
-        if (c == null) throw BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND);
-        List<String> urls = c.getImages().stream().map(Image::getImageUrl).collect(Collectors.toList());
+        if (c == null) { throw BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND);}
+
+        List<String> urls = c.getImages().stream().map(Image::getImageUrl).toList();
+
         return new CommunityDetailResponse(
                 c.getId(), c.getTitle(), c.getContent(),
                 c.getContinent(), c.getCountry(), c.getCity(),

--- a/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReply.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReply.java
@@ -9,7 +9,11 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
+@Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
@@ -33,6 +37,9 @@ public class CommunityReply extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @OneToMany(mappedBy = "reply", orphanRemoval = true)
+    private List<CommunityReplyLike> likes = new ArrayList<>();
+
     public static CommunityReply create(Community community, Member writer, String content) {
         return CommunityReply.builder()
                 .community(community)
@@ -45,5 +52,11 @@ public class CommunityReply extends BaseEntity {
         this.content = content;
     }
 
+    public void addLike(CommunityReplyLike like) {
+        this.likes.add(like);
+        if (like.getReply() != this) {
+            like.setReply(this);
+        }
+    }
 
 }

--- a/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReplyLike.java
+++ b/src/main/java/com/arom/with_travel/domain/community_reply/CommunityReplyLike.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
+@Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -39,6 +39,7 @@ public class Member extends BaseEntity {
     private String oauthId;
 
     private String email;
+    @Column(length = 255) private String password;
 
     private LocalDate birth;
     @Enumerated(EnumType.STRING) private Gender gender;
@@ -129,15 +130,16 @@ public class Member extends BaseEntity {
     private Image image;
 
     @Builder
-    public Member(Long id, String oauthId, String email, String name, LocalDate birth, Gender gender,
-                  String phone, LoginType loginType, String nickname, String introduction,
-                  TravelType travelType, Role role) {
+    public Member(Long id, String oauthId, String email, String password, String name,
+                  LocalDate birth, Gender gender, String phone, LoginType loginType,
+                  String nickname, String introduction, TravelType travelType, Role role) {
         this.id = id;
         this.oauthId = oauthId;
         this.email = email;
+        this.password = password;
+        this.name = name;
         this.birth = birth;
         this.gender = gender;
-        this.name = name;
         this.phone = phone;
         this.loginType = loginType;
         this.nickname = nickname;

--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -6,6 +6,7 @@ import com.arom.with_travel.domain.chat.model.Chat;
 import com.arom.with_travel.domain.chat.model.ChatPart;
 import com.arom.with_travel.domain.community.Community;
 import com.arom.with_travel.domain.community_reply.CommunityReply;
+import com.arom.with_travel.domain.community_reply.CommunityReplyLike;
 import com.arom.with_travel.domain.image.Image;
 import com.arom.with_travel.domain.likes.Likes;
 import com.arom.with_travel.domain.shorts.Shorts;
@@ -105,6 +106,9 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<Community> communities = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
+    private List<CommunityReplyLike> replyLikes = new ArrayList<>();
+
     @OneToMany(mappedBy = "member")
     private List<CommunityReply> communityReplies = new ArrayList<>();
 
@@ -183,5 +187,19 @@ public class Member extends BaseEntity {
     public void addCommunity(Community community) {
         if (community == null) return;
         community.changeMember(this);
+    }
+
+    public void addReply(CommunityReply reply) {
+        this.communityReplies.add(reply);
+        if (reply.getMember() != this) {
+            reply.setMember(this);
+        }
+    }
+
+    public void addReplyLike(CommunityReplyLike like) {
+        this.replyLikes.add(like);
+        if (like.getMember() != this) {
+            like.setMember(this);
+        }
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -179,4 +179,9 @@ public class Member extends BaseEntity {
     public void setSurvey(Survey survey) {
         this.survey = survey;
     }
+
+    public void addCommunity(Community community) {
+        if (community == null) return;
+        community.changeMember(this);
+    }
 }

--- a/src/main/java/com/arom/with_travel/domain/member/dto/request/MemberSignupRequestDto.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/request/MemberSignupRequestDto.java
@@ -3,9 +3,7 @@ package com.arom.with_travel.domain.member.dto.request;
 import com.arom.with_travel.domain.member.Member.Gender;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -32,4 +30,23 @@ public class MemberSignupRequestDto {
     @NotEmpty(message = "자기소개란을 작성해주세요")
     @Schema(description = "짧은 자기소개", example = "안녕하세요")
     private String introduction;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Schema(description = "로그인용 이메일", example = "pikachu@example.com")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 64, message = "비밀번호는 8~64자여야 합니다.")
+    @Schema(description = "로그인 비밀번호(서버에서 해시 저장)", example = "pika1234!")
+    private String password;
+
+    @NotBlank(message = "이름(실명)을 입력해주세요.")
+    @Schema(description = "이름(실명)", example = "한지우")
+    private String name;
+
+    @NotBlank(message = "전화번호를 입력해주세요.")
+    @Pattern(regexp = "^[0-9\\-]{8,15}$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
 }


### PR DESCRIPTION
# 이슈
- #102 

# 구현 기능
### 변경 사항

**회원가입**
- MemberSignupRequestDto: 이름(name), 전화번호(phone), 이메일(email), 비밀번호(password) 필드 추가
- Member 엔티티: password 필드 추가 및 Builder 생성자 보강

**커뮤니티 조회수 증가 로직 개선**
- 조회수 증가 시 커뮤니티 게시글 존재 검증을 선행하고, 최신 viewCount가 반영되도록 로직 수정

**커뮤니티 게시글 수정**
- Community.update() 메서드에서 null 체크 제거 → 수정 하도록 전달된 값으로 전체 필드 일괄 갱신

**커뮤니티 관련 양방향 매핑**
- Community ↔ Member, Community ↔ CommunityReply, CommunityReply ↔ CommunityReplyLike 간 양방향 매핑 및 편의 메서드 추가

### 변경 이유 

**소셜 로그인에서 자체 로그인 전환을 위해 회원가입 시 필수 필드 추가**
- 이름, 전화번호, 이메일, 비밀번호 필드 추가

**일관성 있는 데이터 처리**
- 조회수 증가 시 존재하지 않는 엔티티에 update가 발생하는 문제 예방
  -> 커뮤니티 게시글 존재 검증 로직 추가 및 흐름 명확화

**커뮤니티 게시글 수정 시, 요청 DTO에 담긴 값으로 엔티티 필드를 그대로 갱신하도록 일관화**
- update 메서드의 불필요한 null 체크를 제거하고, API 호출 시 전달된 DTO 값으로 전체 필드를 명확히 덮어쓰도록 변경

**객체 지향적 연관관계 관리**
- 양방향 매핑 및 편의 메서드 추가로 양쪽 관계 동기화 보장
