### PR TITLE
[feat] 자체 회원가입 처리 구현

### DIFF
--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -9,6 +9,7 @@ import com.arom.with_travel.domain.community_reply.CommunityReply;
 import com.arom.with_travel.domain.community_reply.CommunityReplyLike;
 import com.arom.with_travel.domain.image.Image;
 import com.arom.with_travel.domain.likes.Likes;
+import com.arom.with_travel.domain.member.dto.request.MemberSignupRequestDto;
 import com.arom.with_travel.domain.shorts.Shorts;
 import com.arom.with_travel.domain.shorts_reply.ShortsReply;
 import com.arom.with_travel.domain.survey.Survey;
@@ -29,6 +30,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET is_deleted = true, deleted_at = now() where id = ?")
 @SQLRestriction("is_deleted is FALSE")
+@Builder
+@AllArgsConstructor
 public class Member extends BaseEntity {
 
     @Id
@@ -70,7 +73,8 @@ public class Member extends BaseEntity {
     }
 
     public enum LoginType {
-        KAKAO
+        KAKAO,
+        LOCAL
     }
 
     public Member(String memberName, String email, Role role) {
@@ -129,25 +133,6 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member")
     private Image image;
 
-    @Builder
-    public Member(Long id, String oauthId, String email, String password, String name,
-                  LocalDate birth, Gender gender, String phone, LoginType loginType,
-                  String nickname, String introduction, TravelType travelType, Role role) {
-        this.id = id;
-        this.oauthId = oauthId;
-        this.email = email;
-        this.password = password;
-        this.name = name;
-        this.birth = birth;
-        this.gender = gender;
-        this.phone = phone;
-        this.loginType = loginType;
-        this.nickname = nickname;
-        this.introduction = introduction;
-        this.travelType = travelType;
-        this.role = role;
-    }
-
     public void validateNotAlreadyAppliedTo(Accompany accompany) {
         boolean alreadyApplied = accompanyApplies.stream()
                 .anyMatch(apply -> apply.getAccompany().equals(accompany));
@@ -166,12 +151,17 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-    // 신규 회원 추가 정보 등록; 닉네임/생년월일/성별
-    public void updateExtraInfo(String nickname, LocalDate birth, Gender gender, String introduction) {
+    // 신규 회원 추가 정보 등록;
+    public void updateExtraInfo(String nickname, LocalDate birth, Gender gender, String introduction,
+                                String email, String password, String name, String phone) {
         this.nickname = nickname;
         this.birth    = birth;
         this.gender   = gender;
         this.introduction = introduction;
+        this.email    = email;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
     }
 
     public void markAdditionalDataChecked() {

--- a/src/main/java/com/arom/with_travel/domain/member/controller/AuthController.java
+++ b/src/main/java/com/arom/with_travel/domain/member/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.arom.with_travel.domain.member.controller;
+
+import com.arom.with_travel.domain.member.dto.request.LocalLoginRequest;
+import com.arom.with_travel.domain.member.dto.request.SignupWithSurveyRequestDto;
+import com.arom.with_travel.domain.member.dto.response.LoginResponse;
+import com.arom.with_travel.domain.member.service.LocalAuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final LocalAuthService authService;
+
+    // 이메일 중복 체크
+    @GetMapping("/email-available")
+    public boolean emailAvailable(@RequestParam String email) {
+        return authService.isEmailAvailable(email);
+    }
+
+    // 이메일 등록(회원가입)
+    @PostMapping("/register")
+    public ResponseEntity<LoginResponse> register(@Valid @RequestBody SignupWithSurveyRequestDto req) {
+        return ResponseEntity.ok(authService.registerWithSurvey(req));
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public LoginResponse login(@Valid @RequestBody LocalLoginRequest req) {
+        return authService.login(req);
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/member/dto/request/LocalLoginRequest.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/request/LocalLoginRequest.java
@@ -1,0 +1,17 @@
+package com.arom.with_travel.domain.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LocalLoginRequest {
+    @NotBlank @Email
+    private String email;
+
+    @NotBlank @Size(min=8, max=64)
+    private String password;
+}

--- a/src/main/java/com/arom/with_travel/domain/member/dto/request/MemberSignupRequestDto.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/request/MemberSignupRequestDto.java
@@ -46,7 +46,10 @@ public class MemberSignupRequestDto {
     private String name;
 
     @NotBlank(message = "전화번호를 입력해주세요.")
-    @Pattern(regexp = "^[0-9\\-]{8,15}$", message = "전화번호 형식이 올바르지 않습니다.")
+    @Pattern(
+            regexp = "^01[0-9]-\\d{3,4}-\\d{4}$",
+            message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
+    )
     @Schema(description = "전화번호", example = "010-1234-5678")
     private String phone;
 }

--- a/src/main/java/com/arom/with_travel/domain/member/dto/response/LoginResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/member/dto/response/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.arom.with_travel.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private boolean infoChecked;
+}

--- a/src/main/java/com/arom/with_travel/domain/member/service/LocalAuthService.java
+++ b/src/main/java/com/arom/with_travel/domain/member/service/LocalAuthService.java
@@ -87,10 +87,10 @@ public class LocalAuthService {
     @Transactional(readOnly = true)
     public LoginResponse login(LocalLoginRequest req) {
         Member m = memberRepository.findByEmail(req.getEmail())
-                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> BaseException.from(ErrorCode.LOGIN_FAIL));
 
         if (m.getPassword() == null || !passwordEncoder.matches(req.getPassword(), m.getPassword())) {
-            throw BaseException.from(ErrorCode.INVALID_CREDENTIALS);
+            throw BaseException.from(ErrorCode.LOGIN_FAIL);
         }
 
         String access  = jwtProvider.generateAccessToken(m);

--- a/src/main/java/com/arom/with_travel/domain/member/service/LocalAuthService.java
+++ b/src/main/java/com/arom/with_travel/domain/member/service/LocalAuthService.java
@@ -1,0 +1,100 @@
+package com.arom.with_travel.domain.member.service;
+
+import com.arom.with_travel.domain.member.Member;
+import com.arom.with_travel.domain.member.dto.request.LocalLoginRequest;
+import com.arom.with_travel.domain.member.dto.request.MemberSignupRequestDto;
+import com.arom.with_travel.domain.member.dto.request.SignupWithSurveyRequestDto;
+import com.arom.with_travel.domain.member.dto.response.LoginResponse;
+import com.arom.with_travel.domain.member.repository.MemberRepository;
+import com.arom.with_travel.domain.survey.Survey;
+import com.arom.with_travel.domain.survey.dto.request.SurveyRequestDto;
+import com.arom.with_travel.domain.survey.repository.SurveyRepository;
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
+import com.arom.with_travel.global.jwt.dto.response.AuthTokenResponse;
+import com.arom.with_travel.global.security.token.provider.JwtProvider;
+import com.arom.with_travel.global.security.token.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LocalAuthService {
+
+    private final MemberRepository memberRepository;
+    private final SurveyRepository surveyRepository;
+    private final TokenService tokenService;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Transactional(readOnly = true)
+    public boolean isEmailAvailable(String email) {
+        boolean duplicated = memberRepository.existsByEmail(email);
+        return !duplicated;
+    }
+
+    // 신규 회원 추가 정보 + 설문 통합 등록
+    public LoginResponse registerWithSurvey(SignupWithSurveyRequestDto req) {
+
+        String email = req.getExtraInfo().getEmail();
+        if(!isEmailAvailable(email)) {
+            throw BaseException.from(ErrorCode.DUPLICATED_EMAIL);
+        }
+
+        MemberSignupRequestDto extra = req.getExtraInfo();
+        String encodedPassword = passwordEncoder.encode(extra.getPassword());
+
+        Member member = Member.builder()
+                .email(extra.getEmail())
+                .password(encodedPassword)
+                .name(extra.getName())
+                .phone(extra.getPhone())
+                .birth(extra.getBirthdate())
+                .gender(extra.getGender())
+                .nickname(extra.getNickname())
+                .introduction(extra.getIntroduction())
+                .role(Member.Role.USER)
+                .additionalDataChecked(false)
+                .build();
+
+        member = memberRepository.save(member);
+
+        SurveyRequestDto s = req.getSurvey();
+        Survey survey = Survey.create(member, s);
+        surveyRepository.save(survey);
+        member.setSurvey(survey);
+
+        member.markAdditionalDataChecked();
+
+        AuthTokenResponse tokenPair = tokenService.issueTokenPair(member.getEmail());
+
+        return new LoginResponse(
+                tokenPair.getAccessToken(),
+                tokenPair.getRefreshToken(),
+                member.getAdditionalDataChecked()
+        );
+    }
+
+    private Member getUserByLoginEmailOrElseThrow(String loginEmail) {
+        return memberRepository.findByEmail(loginEmail)
+                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    // 로그인: raw, hashed 비번 비교 → 토큰 발급
+    @Transactional(readOnly = true)
+    public LoginResponse login(LocalLoginRequest req) {
+        Member m = memberRepository.findByEmail(req.getEmail())
+                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (m.getPassword() == null || !passwordEncoder.matches(req.getPassword(), m.getPassword())) {
+            throw BaseException.from(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        String access  = jwtProvider.generateAccessToken(m);
+        String refresh = jwtProvider.generateRefreshToken(m);
+        return new LoginResponse(access, refresh, Boolean.TRUE.equals(m.getAdditionalDataChecked()));
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/member/service/MemberSignupService.java
+++ b/src/main/java/com/arom/with_travel/domain/member/service/MemberSignupService.java
@@ -53,7 +53,9 @@ public class MemberSignupService {
         Member member = getUserByLoginEmailOrElseThrow(email);
 
         MemberSignupRequestDto extra = req.getExtraInfo();
-        member.updateExtraInfo(extra.getNickname(), extra.getBirthdate(), extra.getGender(), extra.getIntroduction());
+        member.updateExtraInfo(extra.getNickname(), extra.getBirthdate(), extra.getGender(),
+                extra.getIntroduction(), extra.getEmail(), extra.getPassword(),
+                extra.getName(), extra.getPhone());
 
 //        req.getSurveys().forEach(sdto -> {
 //            Survey survey = Survey.create(member, sdto.getAnswers());
@@ -84,7 +86,7 @@ public class MemberSignupService {
                     return memberRepository.save(inserted);
                 });
     }
-  
+
     private Member getUserByLoginEmailOrElseThrow(String loginEmail) {
         return memberRepository.findByEmail(loginEmail)
                 .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
@@ -97,7 +99,11 @@ public class MemberSignupService {
         member.updateExtraInfo(dto.getNickname(),
                 dto.getBirthdate(),
                 dto.getGender(),
-                dto.getIntroduction());
+                dto.getIntroduction(),
+                dto.getEmail(),
+                dto.getPassword(),
+                dto.getName(),
+                dto.getPhone());
 
         return MemberSignupResponseDto.from(member);
     }

--- a/src/main/java/com/arom/with_travel/global/config/SecurityConfig.java
+++ b/src/main/java/com/arom/with_travel/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -52,7 +53,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/signup/**").permitAll()
                         .requestMatchers("/", "/index/**", "/index.js", "/favicon.ico",
                                 "/templates", "/error", "/v3/api-docs/**", "/swagger-ui/**", "/api/v1/login",
-                                "/actuator/**").permitAll()
+                                "/actuator/**","/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling((exceptionHandling) -> exceptionHandling
@@ -125,6 +126,11 @@ public class SecurityConfig {
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 

--- a/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
@@ -74,7 +74,11 @@ public enum ErrorCode {
 
     // reply
     REPLY_NOT_FOUND("REP-0000", "해당 댓글이 존재하지 않습니다.", ErrorDisplayType.POPUP),
-    REPLY_FORBIDDEN("REP-0001", "해당 댓글에 수정 및 삭제 권한이 없습니다.", ErrorDisplayType.POPUP)
+    REPLY_FORBIDDEN("REP-0001", "해당 댓글에 수정 및 삭제 권한이 없습니다.", ErrorDisplayType.POPUP),
+
+    // login
+    DUPLICATED_EMAIL("LOGIN-0001", "중복된 이메일이 존재합니다.", ErrorDisplayType.POPUP),
+    INVALID_CREDENTIALS("LOGIN-0002", "비밀번호가 올바르지 않습니다.", ErrorDisplayType.POPUP)
     ;
 
     private final String code;

--- a/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
@@ -78,7 +78,8 @@ public enum ErrorCode {
 
     // login
     DUPLICATED_EMAIL("LOGIN-0001", "중복된 이메일이 존재합니다.", ErrorDisplayType.POPUP),
-    INVALID_CREDENTIALS("LOGIN-0002", "비밀번호가 올바르지 않습니다.", ErrorDisplayType.POPUP)
+    INVALID_CREDENTIALS("LOGIN-0002", "비밀번호가 올바르지 않습니다.", ErrorDisplayType.POPUP),
+    LOGIN_FAIL("LOGIN-0003", "로그인 과정이 정상적으로 이루어지지 않았습니다.", ErrorDisplayType.POPUP)
     ;
 
     private final String code;


### PR DESCRIPTION
# 이슈
- #107 


# 변경 요약  
- 소셜 기반 회원가입 → 자체 이메일/비밀번호 회원가입으로 전환  
- 회원가입 시 설문(Survey) 과 회원 추가정보를 동시에 등록  
- 로그인은 이메일 + 비밀번호 조합으로 인증  
- 비밀번호는 BCrypt(PasswordEncoder) 로 해싱 저장 (DB에는 원문 저장 없음)  
- 로그인/가입 완료 시 Access/Refresh 토큰과 추가정보/설문 완료 여부(infoChecked) 반환  

# 변경 사항

1. **회원가입 (이메일 + 비밀번호 방식)**  
   - 사용자가 이메일, 비밀번호, 이름, 닉네임, 성별, 생년월일 같은 기본정보랑 설문지를 같이 제출하면,  
   - 먼저 같은 이메일이 이미 등록돼 있는지 확인하고,  
   - 비밀번호는 그대로 저장하지 않고 "암호화(안전하게 변환)" 해서 DB에 넣어요.  
   - 그 다음 회원 정보를 저장하고, 설문도 같이 연결해서 저장합니다.  
   - 마지막으로 회원이 추가 정보를 다 채웠다는 표시를 해주고, 바로 로그인할 수 있도록 토큰 2개(엑세스·리프레시)를 돌려줍니다.  

2. **로그인 (이메일 + 비밀번호)**  
   - 사용자가 이메일과 비밀번호로 로그인하면,  
   - DB에 저장된 암호화된 비밀번호와 비교해서 맞는지 확인합니다.  
   - 맞으면 토큰 2개(엑세스·리프레시)를 발급해주고, 그 사람이 추가정보/설문까지 끝낸 상태인지 true/false 로 알려줍니다.  

3. **이메일 중복 확인**  
   - 회원가입 전에 이메일이 이미 쓰이고 있는지 확인할 수 있는 기능을 따로 제공합니다.  
   - 결과는 단순히 `true/false` 로 알려줍니다.  (T: 해당 이메일 사용가능/F: 중복 이메일 존재)

4. **보안 처리**  
   - 비밀번호는 절대 그대로 저장하지 않고 암호화해서만 DB에 저장됩니다.  

## 변경 근거
- 외부 소셜 의존 없이 단일(로컬) 로그인 플로우 필요  
- 보안 강화: 비밀번호는 반드시 해시(BCrypt) 로만 저장  
- 프론트에서 추가정보 입력 여부를 바로 구분해야 하므로 `infoChecked` 제공  
