### PR TITLE
[feat] 커뮤니티 태그/좋아요/인기글 기능 및 API 응답 개선, JWT sub 표준화

### DIFF
--- a/src/main/java/com/arom/with_travel/domain/community/Community.java
+++ b/src/main/java/com/arom/with_travel/domain/community/Community.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.community;
 
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import com.arom.with_travel.domain.community_reply.CommunityReply;
 import com.arom.with_travel.domain.image.Image;
 import com.arom.with_travel.domain.member.Member;
@@ -14,16 +15,22 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-@SQLDelete(sql = "UPDATE community SET is_deleted = true, deleted_at = now() where id = ?")
-@SQLRestriction("is_deleted is FALSE")
+@SQLDelete(sql = "UPDATE community SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLRestriction("is_deleted = FALSE")
+@Table(indexes = {
+        @Index(name = "idx_community_tag", columnList = "tag"),
+        @Index(name = "idx_community_created_at", columnList = "created_at"),
+        @Index(name = "idx_community_like_count", columnList = "like_count"),
+        @Index(name = "idx_community_view_count", columnList = "view_count")
+})
 public class Community extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull @Column(length = 120)
@@ -31,6 +38,10 @@ public class Community extends BaseEntity {
 
     @NotNull @Lob
     private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private CommunityTag tag;
 
     @NotNull private String continent;
     @NotNull private String country;
@@ -43,18 +54,27 @@ public class Community extends BaseEntity {
     @OneToMany(mappedBy = "community", orphanRemoval = true)
     private List<CommunityReply> communityReplies = new ArrayList<>();
 
-    @OneToMany(mappedBy = "community")
+    @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<Image> images = new ArrayList<>();
 
-    @Column(nullable = false)
+    @Column(name = "view_count", nullable = false)
     private long viewCount = 0L;
 
+    @Column(name = "like_count", nullable = false)
+    private long likeCount = 0L;
+
+    @Column(name = "reply_count", nullable = false)
+    private long replyCount = 0L;
+
     public static Community create(Member writer, String title, String content,
+                                   CommunityTag tag,
                                    String continent, String country, String city) {
         Community c = Community.builder()
                 .member(writer)
                 .title(title)
                 .content(content)
+                .tag(tag)
                 .continent(continent)
                 .country(country)
                 .city(city)
@@ -80,9 +100,16 @@ public class Community extends BaseEntity {
         }
     }
 
-    public void update(String title, String content, String continent, String country, String city) {
+    public void addImage(Image image) {
+        images.add(image);
+        image.attachToCommunity(this);
+    }
+
+    public void update(String title, String content, CommunityTag tag,
+                       String continent, String country, String city) {
         this.title = title;
         this.content = content;
+        this.tag = tag;
         this.continent = continent;
         this.country = country;
         this.city = city;

--- a/src/main/java/com/arom/with_travel/domain/community/Community.java
+++ b/src/main/java/com/arom/with_travel/domain/community/Community.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/src/main/java/com/arom/with_travel/domain/community/CommunitySpecs.java
+++ b/src/main/java/com/arom/with_travel/domain/community/CommunitySpecs.java
@@ -1,10 +1,15 @@
 package com.arom.with_travel.domain.community;
 
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.util.StringUtils;
 
 public class CommunitySpecs {
     private CommunitySpecs() {}
+
+    public static Specification<Community> tagEq(CommunityTag tag) {
+        return (root, q, cb) -> (tag != null) ? cb.equal(root.get("tag"), tag) : null;
+    }
 
     public static Specification<Community> continentEq(String continent) {
         return (root, q, cb) -> StringUtils.hasText(continent) ? cb.equal(root.get("continent"), continent) : null;

--- a/src/main/java/com/arom/with_travel/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/arom/with_travel/domain/community/controller/CommunityController.java
@@ -4,18 +4,24 @@ import com.arom.with_travel.domain.community.dto.CommunityCreateRequest;
 import com.arom.with_travel.domain.community.dto.CommunityDetailResponse;
 import com.arom.with_travel.domain.community.dto.CommunityListItemResponse;
 import com.arom.with_travel.domain.community.dto.CommunityUpdateRequest;
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import com.arom.with_travel.domain.community.service.CommunityService;
 import com.arom.with_travel.global.security.domain.PrincipalDetails;
-import com.arom.with_travel.global.utils.SecurityUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/communities")
@@ -24,8 +30,10 @@ public class CommunityController {
     private final CommunityService communityService;
 
     @PostMapping
-    public Long create(@AuthenticationPrincipal PrincipalDetails principal,
-                       @RequestBody @Valid CommunityCreateRequest req) {
+    public Long create(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @RequestBody @Valid CommunityCreateRequest req
+    ) {
         String me = principal.getAuthenticatedMember().getEmail();
         return communityService.create(me, req);
     }
@@ -41,22 +49,48 @@ public class CommunityController {
             @RequestParam(required = false) String country,
             @RequestParam(required = false) String city,
             @RequestParam(required = false, name = "q") String keyword,
+            @RequestParam(required = false, name = "tag") CommunityTag tag,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return communityService.search(continent, country, city, keyword, pageable);
+        return communityService.search(continent, country, city, keyword, tag, pageable);
     }
 
     @PatchMapping("/{id}")
-    public void update(@PathVariable Long id, @RequestBody @Valid CommunityUpdateRequest req) {
-        Long me = SecurityUtils.currentMemberIdOrThrow();
-        communityService.update(me, id, req);
+    public CommunityDetailResponse update(
+            @PathVariable Long id,
+            @RequestBody @Valid CommunityUpdateRequest req,
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        Long me = principal.getAuthenticatedMember().getMemberId();
+        return communityService.update(me, id, req);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
-        Long me = SecurityUtils.currentMemberIdOrThrow();
+    public ResponseEntity<Void> delete(
+            @PathVariable Long id,
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        Long me = principal.getAuthenticatedMember().getMemberId();
         communityService.delete(me, id);
+        return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/tags/{tag}")
+    public Page<CommunityListItemResponse> listByTag(
+            @PathVariable CommunityTag tag,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        int limitedSize = Math.min(Math.max(size, 1), 50);
+
+        Pageable pageable = PageRequest.of(
+                page,
+                limitedSize,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+        return communityService.listByTag(tag, pageable);
+    }
+
 }

--- a/src/main/java/com/arom/with_travel/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/arom/with_travel/domain/community/controller/CommunityController.java
@@ -57,6 +57,21 @@ public class CommunityController {
         return communityService.search(continent, country, city, keyword, tag, pageable);
     }
 
+    @GetMapping("/top-liked")
+    public List<CommunityListItemResponse> topLiked() {
+        return communityService.topLiked();
+    }
+
+    @PostMapping("/{id}/like")
+    public Map<String, Object> toggleLike(
+            @PathVariable Long id,
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        Long me = principal.getAuthenticatedMember().getMemberId();
+        boolean liked = communityService.toggleLike(id, me);
+        return Map.of("liked", liked);
+    }
+
     @PatchMapping("/{id}")
     public CommunityDetailResponse update(
             @PathVariable Long id,

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityCreateRequest.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityCreateRequest.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.community.dto;
 
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -17,6 +18,7 @@ public class CommunityCreateRequest {
     @NotEmpty String continent;
     @NotEmpty String country;
     @NotEmpty String city;
+    private CommunityTag tag;
     private List<ImageCreate> images;
 
     @Getter

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponse.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.community.dto;
 
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,12 +14,15 @@ public class CommunityDetailResponse {
     Long id;
     String title;
     String content;
+    private CommunityTag tag;
     String continent;
     String country;
     String city;
     Long writerId;
     String writerNickname;
     long viewCount;
+    long likeCount;
+    long replyCount;
     List<String> imageUrls;
     String createdAt;
     String updatedAt;

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponseMapper.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityDetailResponseMapper.java
@@ -1,0 +1,27 @@
+package com.arom.with_travel.domain.community.dto;
+
+import com.arom.with_travel.domain.community.Community;
+import com.arom.with_travel.domain.image.Image;
+
+public class CommunityDetailResponseMapper {
+
+    public static CommunityDetailResponse from(Community c) {
+        return new CommunityDetailResponse(
+                c.getId(),
+                c.getTitle(),
+                c.getContent(),
+                c.getTag(),
+                c.getContinent(),
+                c.getCountry(),
+                c.getCity(),
+                c.getMember().getId(),
+                c.getMember().getNickname(),
+                c.getViewCount(),
+                c.getLikeCount(),
+                c.getReplyCount(),
+                c.getImages().stream().map(Image::getImageUrl).toList(),
+                c.getCreatedAt().toString(),
+                c.getUpdatedAt().toString()
+        );
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityListItemResponse.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityListItemResponse.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.community.dto;
 
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,11 +12,14 @@ public class CommunityListItemResponse {
     Long id;
     String title;
     String snippet;
+    CommunityTag tag;
     String continent;
     String country;
     String city;
     Long writerId;
     String writerNickname;
     long viewCount;
+    long likeCount;
+    long replyCount;
     String createdAt;
 }

--- a/src/main/java/com/arom/with_travel/domain/community/dto/CommunityUpdateRequest.java
+++ b/src/main/java/com/arom/with_travel/domain/community/dto/CommunityUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.arom.with_travel.domain.community.dto;
 
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ public class CommunityUpdateRequest {
     private String continent;
     private String country;
     private String city;
+    private CommunityTag tag;
     private List<ImageUpdate> images;
 
     @Getter

--- a/src/main/java/com/arom/with_travel/domain/community/enums/CommunityTag.java
+++ b/src/main/java/com/arom/with_travel/domain/community/enums/CommunityTag.java
@@ -1,0 +1,40 @@
+package com.arom.with_travel.domain.community.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum CommunityTag {
+    RESTAURANT("맛집추천"),
+    CAFE("카페탐방"),
+    INFO("정보공유"),
+    TIPS("꿀팁");
+
+    private final String labelKo;
+
+    CommunityTag(String labelKo) {
+        this.labelKo = labelKo;
+    }
+
+    public String getLabelKo() {
+        return labelKo;
+    }
+
+    @JsonCreator
+    public static CommunityTag from(String v) {
+        if (v == null) return null;
+        String key = v.trim();
+        String upper = key.toUpperCase();
+
+        return Arrays.stream(values())
+                .filter(e -> e.name().equalsIgnoreCase(upper) || e.labelKo.equalsIgnoreCase(key))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown tag: " + v));
+    }
+
+    @JsonValue
+    public String toValue() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/arom/with_travel/domain/community/repository/CommunityRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/community/repository/CommunityRepository.java
@@ -19,8 +19,14 @@ public interface CommunityRepository extends JpaRepository<Community, Long>,
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Community c set c.viewCount = c.viewCount + 1 where c.id = :id")
     int increaseViewCount(Long id);
-    
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Community c set c.likeCount = c.likeCount + :delta where c.id = :id")
+    int addLikeCount(Long id, long delta);
+
     Page<Community> findByTagOrderByCreatedAtDesc(CommunityTag tag, Pageable pageable);
+
+    List<Community> findTop2ByOrderByLikeCountDescIdDesc();
 
     default Page<Community> search(Specification<Community> spec, Pageable pageable) {
         return this.findAll(spec, pageable);

--- a/src/main/java/com/arom/with_travel/domain/community/repository/CommunityRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/community/repository/CommunityRepository.java
@@ -1,10 +1,13 @@
 package com.arom.with_travel.domain.community.repository;
 
 import com.arom.with_travel.domain.community.Community;
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.*;
+
+import java.util.List;
 
 public interface CommunityRepository extends JpaRepository<Community, Long>,
         JpaSpecificationExecutor<Community> {
@@ -16,6 +19,8 @@ public interface CommunityRepository extends JpaRepository<Community, Long>,
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Community c set c.viewCount = c.viewCount + 1 where c.id = :id")
     int increaseViewCount(Long id);
+    
+    Page<Community> findByTagOrderByCreatedAtDesc(CommunityTag tag, Pageable pageable);
 
     default Page<Community> search(Specification<Community> spec, Pageable pageable) {
         return this.findAll(spec, pageable);

--- a/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
+++ b/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
@@ -197,6 +197,40 @@ public class CommunityService {
                 ));
     }
 
+    @Transactional(readOnly = true)
+    public List<CommunityListItemResponse> topLiked() {
+        return communityRepository.findTop2ByOrderByLikeCountDescIdDesc().stream()
+                .map(c -> new CommunityListItemResponse(
+                        c.getId(), c.getTitle(),
+                        c.getContent().length() > 30 ? c.getContent().substring(0, 30) + "..." : c.getContent(),
+                        c.getTag(), c.getContinent(), c.getCountry(), c.getCity(),
+                        c.getMember().getId(), c.getMember().getNickname(),
+                        c.getViewCount(), c.getLikeCount(), c.getReplyCount(),
+                        c.getCreatedAt().toString()
+                ))
+                .toList();
+    }
+
+    @Transactional
+    public boolean toggleLike(Long communityId, Long currentMemberId) {
+        Community c = communityRepository.findById(communityId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND));
+        Member m = memberRepository.findById(currentMemberId)
+                .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
+
+        return likesRepository.findByCommunityIdAndMemberId(communityId, currentMemberId)
+                .map(existing -> {
+                    likesRepository.delete(existing);
+                    communityRepository.addLikeCount(communityId, -1);
+                    return false;
+                })
+                .orElseGet(() -> {
+                    likesRepository.save(Likes.forCommunity(m, c));
+                    communityRepository.addLikeCount(communityId, +1);
+                    return true;
+                });
+    }
+
     private void validateOwnership(Long currentMemberId, Long ownerId) {
         if (!ownerId.equals(currentMemberId)) {
             throw BaseException.from(ErrorCode.COMMUNITY_FORBIDDEN);

--- a/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
+++ b/src/main/java/com/arom/with_travel/domain/community/service/CommunityService.java
@@ -1,18 +1,20 @@
 package com.arom.with_travel.domain.community.service;
 
 import com.arom.with_travel.domain.community.Community;
-import com.arom.with_travel.domain.community.dto.CommunityCreateRequest;
-import com.arom.with_travel.domain.community.dto.CommunityDetailResponse;
-import com.arom.with_travel.domain.community.dto.CommunityListItemResponse;
-import com.arom.with_travel.domain.community.dto.CommunityUpdateRequest;
+import com.arom.with_travel.domain.community.CommunitySpecs;
+import com.arom.with_travel.domain.community.dto.*;
+import com.arom.with_travel.domain.community.enums.CommunityTag;
 import com.arom.with_travel.domain.community.repository.CommunityRepository;
 import com.arom.with_travel.domain.image.Image;
 import com.arom.with_travel.domain.image.repository.ImageRepository;
+import com.arom.with_travel.domain.likes.Likes;
+import com.arom.with_travel.domain.likes.repository.LikesRepository;
 import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.member.repository.MemberRepository;
 import com.arom.with_travel.global.exception.BaseException;
 import com.arom.with_travel.global.exception.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -20,10 +22,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.arom.with_travel.domain.community.CommunitySpecs.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CommunityService {
@@ -31,16 +33,24 @@ public class CommunityService {
     private final CommunityRepository communityRepository;
     private final MemberRepository memberRepository;
     private final ImageRepository imageRepository;
+    private final LikesRepository likesRepository;
 
     @Transactional
     public Long create(String currentMemberEmail, CommunityCreateRequest req) {
         Member writer = memberRepository.findByEmail(currentMemberEmail)
                 .orElseThrow(() -> BaseException.from(ErrorCode.MEMBER_NOT_FOUND));
 
-        Community saved = communityRepository.save(
-                Community.create(writer, req.getTitle(), req.getContent(),
-                        req.getContinent(), req.getCountry(), req.getCity())
+        Community community = Community.create(
+                writer,
+                req.getTitle(),
+                req.getContent(),
+                req.getTag(),
+                req.getContinent(),
+                req.getCountry(),
+                req.getCity()
         );
+
+        Community saved = communityRepository.save(community);
 
         if (req.getImages() != null) {
             List<Image> newImages = req.getImages().stream()
@@ -50,8 +60,15 @@ public class CommunityService {
                             saved
                     ))
                     .toList();
-            if (!newImages.isEmpty()) imageRepository.saveAll(newImages);
+            try {
+                if (!newImages.isEmpty()) {
+                    imageRepository.saveAll(newImages);
+                }
+            } catch (Exception e) {
+                throw BaseException.from(ErrorCode.IMG_SAVE_FAIL);
+            }
         }
+
         return saved.getId();
     }
 
@@ -74,43 +91,57 @@ public class CommunityService {
             throw BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND);
         }
 
-        int updated = communityRepository.increaseViewCount(id);
+        communityRepository.increaseViewCount(id);
 
         Community c = communityRepository.findDetailById(id);
-        if (c == null) { throw BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND);}
+        if (c == null) {
+            throw BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND);
+        }
 
         List<String> urls = c.getImages().stream().map(Image::getImageUrl).toList();
 
         return new CommunityDetailResponse(
-                c.getId(), c.getTitle(), c.getContent(),
+                c.getId(), c.getTitle(), c.getContent(), c.getTag(),
                 c.getContinent(), c.getCountry(), c.getCity(),
                 c.getMember().getId(), c.getMember().getNickname(),
-                c.getViewCount(), urls,
-                c.getCreatedAt().toString(), c.getUpdatedAt().toString()
+                c.getViewCount(), c.getLikeCount(), c.getReplyCount(),
+                urls, c.getCreatedAt().toString(), c.getUpdatedAt().toString()
         );
     }
 
     @Transactional
-    public void update(Long currentMemberId, Long communityId, CommunityUpdateRequest req) {
+    public CommunityDetailResponse update(Long currentMemberId, Long communityId, CommunityUpdateRequest req) {
         Community c = communityRepository.findById(communityId)
                 .orElseThrow(() -> BaseException.from(ErrorCode.COMMUNITY_NOT_FOUND));
         validateOwnership(currentMemberId, c.getMember().getId());
 
-        c.update(req.getTitle(), req.getContent(), req.getContinent(), req.getCountry(), req.getCity());
+        c.update(
+                req.getTitle(),
+                req.getContent(),
+                req.getTag(),
+                req.getContinent(),
+                req.getCountry(),
+                req.getCity()
+        );
 
         if (req.getImages() != null) {
-            c.getImages().forEach(Image::detachFromCommunity);
+            c.getImages().clear();
 
             List<Image> newImages = req.getImages().stream()
-                    .map(img -> Image.fromCommunity(
-                            defaultName(img.getImageName()),
-                            requireUrl(img.getImageUrl()),
+                    .map(imgReq -> Image.fromCommunity(
+                            defaultName(imgReq.getImageName()),
+                            requireUrl(imgReq.getImageUrl()),
                             c
                     ))
                     .toList();
 
-            if (!newImages.isEmpty()) imageRepository.saveAll(newImages);
+            if (!newImages.isEmpty()) {
+                imageRepository.saveAll(newImages);
+            }
+            c.getImages().addAll(newImages);
         }
+
+        return CommunityDetailResponseMapper.from(c);
     }
 
     @Transactional
@@ -121,11 +152,18 @@ public class CommunityService {
         communityRepository.delete(c);
     }
 
-    @Transactional
-    public Page<CommunityListItemResponse> search(String continent, String country, String city, String q,
-                                                  Pageable pageable) {
+    @Transactional(readOnly = true)
+    public Page<CommunityListItemResponse> search(
+            String continent,
+            String country,
+            String city,
+            String q,
+            CommunityTag tag,
+            Pageable pageable
+    ) {
         Specification<Community> spec = Specification
-                .where(continentEq(continent))
+                .where(CommunitySpecs.tagEq(tag))
+                .and(continentEq(continent))
                 .and(countryEq(country))
                 .and(cityEq(city))
                 .and(keywordLike(q));
@@ -135,10 +173,26 @@ public class CommunityService {
                         c.getId(),
                         c.getTitle(),
                         c.getContent().length() > 30 ? c.getContent().substring(0, 30) + "..." : c.getContent(),
+                        c.getTag(),
                         c.getContinent(), c.getCountry(), c.getCity(),
                         c.getMember().getId(),
                         c.getMember().getNickname(),
                         c.getViewCount(),
+                        c.getLikeCount(),
+                        c.getReplyCount(),
+                        c.getCreatedAt().toString()
+                ));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CommunityListItemResponse> listByTag(CommunityTag tag, Pageable pageable) {
+        return communityRepository.findByTagOrderByCreatedAtDesc(tag, pageable)
+                .map(c -> new CommunityListItemResponse(
+                        c.getId(), c.getTitle(),
+                        c.getContent().length() > 30 ? c.getContent().substring(0, 30) + "..." : c.getContent(),
+                        c.getTag(), c.getContinent(), c.getCountry(), c.getCity(),
+                        c.getMember().getId(), c.getMember().getNickname(),
+                        c.getViewCount(), c.getLikeCount(), c.getReplyCount(),
                         c.getCreatedAt().toString()
                 ));
     }

--- a/src/main/java/com/arom/with_travel/domain/likes/Likes.java
+++ b/src/main/java/com/arom/with_travel/domain/likes/Likes.java
@@ -1,6 +1,7 @@
 package com.arom.with_travel.domain.likes;
 
 import com.arom.with_travel.domain.accompanies.model.Accompany;
+import com.arom.with_travel.domain.community.Community;
 import com.arom.with_travel.domain.member.Member;
 import com.arom.with_travel.domain.shorts.Shorts;
 import com.arom.with_travel.global.entity.BaseEntity;
@@ -35,6 +36,10 @@ public class Likes extends BaseEntity {
     @JoinColumn(name = "accompanies_id")
     private Accompany accompany;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "community_id")
+    private Community community;
+
     @Builder
     public Likes(Member member, Accompany accompany) {
         this.member = member;
@@ -50,5 +55,12 @@ public class Likes extends BaseEntity {
 
     public static Likes create(Member member, Accompany accompany){
         return new Likes(member, accompany);
+    }
+
+    public static Likes forCommunity(Member member, Community community) {
+        Likes l = new Likes();
+        l.member = member;
+        l.community = community;
+        return l;
     }
 }

--- a/src/main/java/com/arom/with_travel/domain/likes/repository/LikesRepository.java
+++ b/src/main/java/com/arom/with_travel/domain/likes/repository/LikesRepository.java
@@ -16,4 +16,9 @@ public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     @Query("SELECT COUNT(l) FROM Likes l WHERE l.accompany.id = :accompanyId")
     long countByAccompanyId(@Param("accompanyId") Long accompanyId);
+
+    Optional<Likes> findByCommunityIdAndMemberId(Long communityId, Long memberId);
+    boolean existsByCommunityIdAndMemberId(Long communityId, Long memberId);
+    @Query("SELECT COUNT(l) FROM Likes l WHERE l.community.id = :communityId")
+    long countByCommunityId(@Param("communityId") Long communityId);
 }

--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -38,7 +38,6 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //@Column(unique = true)
     private String oauthId;
 
     private String email;

--- a/src/main/java/com/arom/with_travel/domain/member/Member.java
+++ b/src/main/java/com/arom/with_travel/domain/member/Member.java
@@ -38,7 +38,7 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    //@Column(unique = true)
     private String oauthId;
 
     private String email;

--- a/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/arom/with_travel/global/exception/error/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     // image
     INVALID_IMG_TYPE("IMG-0000", "지원하지 않는 이미지 형식입니다.", ErrorDisplayType.POPUP),
     IMG_URL_MUST_FILLED("IMG-0001", "이미지 url이 존재해야합니다.", ErrorDisplayType.POPUP),
+    IMG_SAVE_FAIL("IMG-0002", "이미지 저장에 실패했습니다.", ErrorDisplayType.POPUP),
 
     // community
     CONTINENT_NOT_FOUND("COM-0000", "해당 대륙이 존재하지 않습니다.", ErrorDisplayType.POPUP),
@@ -79,7 +80,10 @@ public enum ErrorCode {
     // login
     DUPLICATED_EMAIL("LOGIN-0001", "중복된 이메일이 존재합니다.", ErrorDisplayType.POPUP),
     INVALID_CREDENTIALS("LOGIN-0002", "비밀번호가 올바르지 않습니다.", ErrorDisplayType.POPUP),
-    LOGIN_FAIL("LOGIN-0003", "로그인 과정이 정상적으로 이루어지지 않았습니다.", ErrorDisplayType.POPUP)
+    LOGIN_FAIL("LOGIN-0003", "로그인 과정이 정상적으로 이루어지지 않았습니다.", ErrorDisplayType.POPUP),
+
+    // Auth / Security
+    AUTH_UNSUPPORTED_PRINCIPAL("AUTH-0001", "지원하지 않는 인증 주체입니다.", ErrorDisplayType.POPUP)
     ;
 
     private final String code;

--- a/src/main/java/com/arom/with_travel/global/security/domain/AuthenticatedMember.java
+++ b/src/main/java/com/arom/with_travel/global/security/domain/AuthenticatedMember.java
@@ -9,11 +9,13 @@ import lombok.Getter;
 public class AuthenticatedMember {
     private Long memberId;
     private String email;
+    private final String role;
 
     public static AuthenticatedMember from(Member member){
         return new AuthenticatedMember(
                 member.getId(),
-                member.getEmail()
+                member.getEmail(),
+                member.getRole().name()
         );
     }
 }

--- a/src/main/java/com/arom/with_travel/global/security/filter/JwtFilter.java
+++ b/src/main/java/com/arom/with_travel/global/security/filter/JwtFilter.java
@@ -40,23 +40,27 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
+
         String token = resolveToken(request);
-        String aud = jwtProvider.parseAudience(token);
-        PrincipalDetails principalDetails = memberDetailsService.loadUserByUsername(aud);
-        Authentication authentication
-                = new UsernamePasswordAuthenticationToken(
-                principalDetails,
+        String email = jwtProvider.getEmailFromAccessToken(token);
+        PrincipalDetails pd = memberDetailsService.loadUserByUsername(email);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                pd,
                 null,
-                principalDetails.getAuthorities());
+                pd.getAuthorities()
+        );
+
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         context.setAuthentication(authentication);
         SecurityContextHolder.setContext(context);
         securityContextRepository.saveContext(context, request, response);
+
         filterChain.doFilter(request, response);
     }
 
-    private String resolveToken(HttpServletRequest httpServletRequest) {
-        String authorization = httpServletRequest.getHeader(HEADER_AUTHORIZATION);
+    private String resolveToken(HttpServletRequest req) {
+        String authorization = req.getHeader(HEADER_AUTHORIZATION);
         if (authorization == null) {
             throw BaseException.from(EMPTY_TOKEN_PROVIDED);
         }

--- a/src/main/java/com/arom/with_travel/global/security/token/provider/JwtProvider.java
+++ b/src/main/java/com/arom/with_travel/global/security/token/provider/JwtProvider.java
@@ -22,7 +22,7 @@ import static com.arom.with_travel.global.security.token.properties.JwtPropertie
 @Getter
 @Component
 @Slf4j
-public class JwtProvider{
+public class JwtProvider {
 
     private final SecretKey SECRET_KEY;
     private final String ISS;
@@ -38,58 +38,83 @@ public class JwtProvider{
     }
 
     public String generateAccessToken(Member member) {
-        String token = Jwts.builder()
+        return Jwts.builder()
                 .claim("type", "access")
                 .issuedAt(new Date())
+                .subject(member.getEmail())
                 .issuer(ISS)
-                .audience()
-                    .add(member.getEmail())
-                    .add(String.valueOf(member.getId()))
-                    .add(member.getRole().name()).and()
-                .expiration(new Date(new Date().getTime() + ACCESS_TOKEN_EXPIRE_TIME))
+                .id(java.util.UUID.randomUUID().toString())
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRE_TIME))
                 .signWith(SECRET_KEY)
                 .compact();
-        log.info("[generateAccessToken] {}", token);
-        return token;
     }
 
     public String generateRefreshToken(Member member) {
-        String token = Jwts.builder()
+        return Jwts.builder()
                 .claim("type", "refresh")
                 .issuedAt(new Date())
+                .subject(member.getEmail())
                 .issuer(ISS)
                 .audience()
                 .add(String.valueOf(member.getId())).and()
-                .expiration(new Date(new Date().getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+                .id(java.util.UUID.randomUUID().toString())
+                .expiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRE_TIME))
                 .signWith(SECRET_KEY)
                 .compact();
-        log.info("[generateRefreshToken] {}", token);
-        return token;
     }
 
-    public String parseAudience(String token) {
+    public String getEmailFromAccessToken(String token) {
+        Jws<Claims> claims = Jwts.parser().verifyWith(SECRET_KEY).build().parseSignedClaims(token);
+        Claims body = claims.getPayload();
+        if (body.getExpiration().before(new Date())) {
+            throw BaseException.from(EXPIRED_ACCESS_TOKEN);
+        }
+        if (!"access".equals(body.get("type", String.class))) {
+            throw BaseException.from(INVALID_TOKEN);
+        }
+        return body.getSubject();
+    }
+
+    public void validateAudience(String token, String expectedAud) {
         try {
-            Jws<Claims> claims = Jwts.parser()
-                    .verifyWith(SECRET_KEY)
-                    .build()
-                    .parseSignedClaims(token);
-            if (claims.getPayload()
-                    .getExpiration()
-                    .before(new Date())) {
+            Jws<Claims> claims = Jwts.parser().verifyWith(SECRET_KEY).build().parseSignedClaims(token);
+            Claims body = claims.getPayload();
+            if (body.getExpiration().before(new Date())) {
                 throw BaseException.from(EXPIRED_ACCESS_TOKEN);
             }
-            return claims.getPayload()
-                    .getAudience()
-                    .iterator()
-                    .next();
-        } catch (JwtException | IllegalArgumentException e) {
-            log.warn("[parseAudience] {} :{}", INVALID_TOKEN, token);
-            throw BaseException.from(INVALID_TOKEN);
+            var audiences = body.getAudience();
+            if (audiences == null || !audiences.contains(expectedAud)) {
+                throw BaseException.from(INVALID_TOKEN);
+            }
         } catch (BaseException e) {
-            log.warn("[parseAudience] {} :{}", EXPIRED_ACCESS_TOKEN, token);
+            // 만료 등 우리 쪽 예외만 캐치해서 동일 코드로 재던짐(스크린샷 흐름 반영)
             throw BaseException.from(EXPIRED_ACCESS_TOKEN);
         }
     }
+
+//    public String parseAudience(String token) {
+//        try {
+//            Jws<Claims> claims = Jwts.parser()
+//                    .verifyWith(SECRET_KEY)
+//                    .build()
+//                    .parseSignedClaims(token);
+//            if (claims.getPayload()
+//                    .getExpiration()
+//                    .before(new Date())) {
+//                throw BaseException.from(EXPIRED_ACCESS_TOKEN);
+//            }
+//            return claims.getPayload()
+//                    .getAudience()
+//                    .iterator()
+//                    .next();
+//        } catch (JwtException | IllegalArgumentException e) {
+//            log.warn("[parseAudience] {} :{}", INVALID_TOKEN, token);
+//            throw BaseException.from(INVALID_TOKEN);
+//        } catch (BaseException e) {
+//            log.warn("[parseAudience] {} :{}", EXPIRED_ACCESS_TOKEN, token);
+//            throw BaseException.from(EXPIRED_ACCESS_TOKEN);
+//        }
+//    }
 
     public boolean isRefreshTokenExpired(String token) {
         try {
@@ -102,12 +127,12 @@ public class JwtProvider{
             String type = body.get("type", String.class);
 
             if (!"refresh".equals(type)) {
-                throw BaseException.from(INVALID_TOKEN); // 타입이 refresh가 아닐 경우
+                throw BaseException.from(INVALID_TOKEN);
             }
 
             return body.getExpiration().before(new Date());
         } catch (JwtException e) {
-            throw BaseException.from(INVALID_TOKEN); // 구조가 잘못되었거나 서명 불일치
+            throw BaseException.from(INVALID_TOKEN);
         }
     }
 }

--- a/src/main/java/com/arom/with_travel/global/utils/SecurityUtils.java
+++ b/src/main/java/com/arom/with_travel/global/utils/SecurityUtils.java
@@ -1,6 +1,9 @@
 package com.arom.with_travel.global.utils;
 
+import com.arom.with_travel.global.exception.BaseException;
+import com.arom.with_travel.global.exception.error.ErrorCode;
 import com.arom.with_travel.global.security.domain.AuthenticatedMember;
+import com.arom.with_travel.global.security.domain.PrincipalDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -10,15 +13,19 @@ public final class SecurityUtils {
 
     public static Long currentMemberIdOrThrow() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || !auth.isAuthenticated()) {
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
             throw new IllegalStateException("Unauthenticated");
         }
+
         Object principal = auth.getPrincipal();
 
-        if (principal instanceof AuthenticatedMember authenticatedMember) {
-            return authenticatedMember.getMemberId();
+        if (principal instanceof PrincipalDetails pd) {
+            return pd.getAuthenticatedMember().getMemberId();
+        }
+        if (principal instanceof AuthenticatedMember am) {
+            return am.getMemberId();
         }
 
-        throw new IllegalStateException("Unsupported principal: " + principal);
+        throw BaseException.from(ErrorCode.AUTH_UNSUPPORTED_PRINCIPAL);
     }
 }


### PR DESCRIPTION
# 이슈
- #102 

# 구현 기능

### 변경 요약
- JWT 파싱 기준 변경: 토큰에서 이메일을 aud가 아닌 sub로 파싱하도록 변경
  - aud는 “토큰 대상(서비스)” 식별자, sub는 “주체(사용자)” 식별자이므로 표준 의미에 맞게 정정. 
  - aud 배열/검증 충돌 이슈 제거, 파싱 단순화.

- 커뮤니티 태그 도입(4종): RESTAURANT(맛집추천), CAFE(카페탐방), INFO(정보공유), TIPS(꿀팁)
  - 태그별 최신순 목록/검색 가능(대륙/국가/도시/키워드 필터와 병행).

- 좋아요 기능 추가
  - 토글 API: 같은 버튼으로 좋아요/취소, 서버가 카운트 자동 증감(+1/−1)
  - 인기 글 API: 좋아요 상위 2개 조회(메인 노출용).

- 수정/삭제 응답 정리
  - 수정 API: 편의를 위해 업데이트된 상세 DTO 즉시 반환(추가 조회 불필요)
  - 삭제 API: HTTP 204 No Content로 REST 관례 준수(본문 없음).

- SecurityUtils 보강
  - principal 타입을 AuthenticatedMember와 PrincipalDetails 모두 지원하도록 분기 → ClassCastException 방지, 인증 주체 ID 추출 로직 단순화/안정화.

### 주요 변경 파일/포인트
- JwtFilter/검증 로직: sub=email 사용, aud는 서비스 식별자 검증용으로 유지
- CommunityTag enum: 4개 카테고리 추가
- 목록/검색/태그별/인기글/좋아요 토글 API 추가/정리(최신순 정렬)
- 수정 API 응답: 업데이트된 CommunityDetailResponse 반환
- 삭제 API 응답: 204 No Content
- SecurityUtils.currentMemberIdOrThrow():
  - 인증 객체 null/미인증 가드 단순화
  - principal 다형성 분기로 안전한 memberId 추출
  - 미지원 principal 시 AUTH_UNSUPPORTED_PRINCIPAL 처리

### 변경 이유 
- JWT 표준/안정성: sub는 사용자, aud는 대상 서비스 → 의미대로 쓰면 파싱/검증 충돌이 사라짐.
- UX/레이아웃: 태그/인기글/좋아요로 카드형 목록 구성 쉬움, 메인 섹션 바로 구성 가능.
- REST 관례: 수정 시 리소스 상태 반환, 삭제는 204 → 클라이언트 로직 단순화.
- 안전성: SecurityUtils에서 principal 타입 케이스를 명시 처리 → 캐스팅 오류 예방.
